### PR TITLE
Feat/limit event max duration

### DIFF
--- a/src/entities/Event/routes/createEvent.ts
+++ b/src/entities/Event/routes/createEvent.ts
@@ -5,15 +5,14 @@ import EventModel from "../model"
 import { eventTargetUrl, calculateRecurrentProperties } from "../utils"
 import RequestError from "decentraland-gatsby/dist/entities/Route/error"
 import { WithAuth } from "decentraland-gatsby/dist/entities/Auth/middleware"
-import { EventAttributes, DeprecatedEventAttributes } from "../types"
+import { EventAttributes, DeprecatedEventAttributes, MAX_EVENT_DURATION } from "../types"
 import { WithAuthProfile } from "decentraland-gatsby/dist/entities/Profile/middleware"
 import { notifyNewEvent } from "../../Slack/utils"
 import API from "decentraland-gatsby/dist/utils/api/API"
 import { createValidator } from "decentraland-gatsby/dist/entities/Route/validate"
 import { newEventSchema } from "../schemas"
 import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
-
-const MAX_EVENT_DURATION = 1000 * 60 * 60 * 24
+import Time from "decentraland-gatsby/dist/utils/date/Time"
 
 const validateNewEvent = createValidator<EventAttributes>(
   newEventSchema as AjvObjectSchema
@@ -63,7 +62,7 @@ export async function createEvent(req: WithAuthProfile<WithAuth>) {
    */
   if (recurrent.duration > MAX_EVENT_DURATION) {
     throw new RequestError(
-      `Maximum allowed duration ${(MAX_EVENT_DURATION / 3600000)}Hrs`,
+      `Maximum allowed duration ${(MAX_EVENT_DURATION / Time.Hour)}Hrs`,
       RequestError.BadRequest,
       { body: data }
     )

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -1,4 +1,5 @@
 import { SQLStatement } from "decentraland-gatsby/dist/entities/Database/utils"
+import Time from "decentraland-gatsby/dist/utils/date/Time"
 
 export enum Frequency {
   YEARLY = "YEARLY",
@@ -222,3 +223,6 @@ export const adminPatchAttributes: (keyof EventAttributes)[] =
   editableAttributes.concat(["approved", "highlighted", "trending", "url"])
 
 export const SITEMAP_ITEMS_PER_PAGE = 100
+
+export const DEFAULT_EVENT_DURATION = Time.Hour
+export const MAX_EVENT_DURATION = Time.Day

--- a/src/hooks/useEventEditor.ts
+++ b/src/hooks/useEventEditor.ts
@@ -13,6 +13,7 @@ import { EditEvent } from "../api/Events"
 import { newEventSchema } from "../entities/Event/schemas"
 
 const DEFAULT_EVENT_DURATION = 1000 * 60 * 60
+const MAX_EVENT_DURATION = 1000 * 60 * 60 * 24
 
 type EventEditorState = EditEvent & {
   errors: Record<string, string>
@@ -108,6 +109,14 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
     // return finish_at.toInputTime()
   }
 
+  /**
+   * Return the max duration event in hours like 24Hrs
+   * @returns 
+   */
+  function getMaxHoursAllowedLabel() : string {
+    return MAX_EVENT_DURATION / 3600000 + "Hrs"
+  }
+
   function setError(key: string, description: string) {
     setEvent((current) => {
       return {
@@ -180,6 +189,7 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
 
       setValues({
         start_at,
+        duration: MAX_EVENT_DURATION, // When change start date, set max duration
         recurrent_until,
         recurrent_monthday: null,
         recurrent_setpos: null,
@@ -217,7 +227,8 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
       0,
       finish_date.getTime() + finish_time.getTime() - event.start_at.getTime()
     )
-    if (duration !== event.duration) {
+    // Change duration only if it's a different value and if it's less or equals to the max duration allowed
+    if (duration !== event.duration && duration <= MAX_EVENT_DURATION) {
       setValues({ duration })
     }
   }
@@ -233,7 +244,8 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
       0,
       finish_date.getTime() + finish_time.getTime() - event.start_at.getTime()
     )
-    if (duration !== event.duration) {
+    // Change duration only if it's a different value and if it's less or equals to the max duration allowed
+    if (duration !== event.duration && duration <= MAX_EVENT_DURATION) {
       setValues({ duration })
     }
   }
@@ -617,6 +629,7 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
     getStartTime,
     getFinishDate,
     getFinishTime,
+    getMaxHoursAllowedLabel,
     setValue,
     setValues,
     setError,

--- a/src/hooks/useEventEditor.ts
+++ b/src/hooks/useEventEditor.ts
@@ -7,13 +7,12 @@ import {
   MonthMask,
   Position,
   MAX_EVENT_RECURRENT,
+  DEFAULT_EVENT_DURATION, 
+  MAX_EVENT_DURATION
 } from "../entities/Event/types"
 import { toWeekdayMask, toRecurrentSetpos } from "../entities/Event/utils"
 import { EditEvent } from "../api/Events"
 import { newEventSchema } from "../entities/Event/schemas"
-
-const DEFAULT_EVENT_DURATION = 1000 * 60 * 60
-const MAX_EVENT_DURATION = 1000 * 60 * 60 * 24
 
 type EventEditorState = EditEvent & {
   errors: Record<string, string>
@@ -114,7 +113,7 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
    * @returns 
    */
   function getMaxHoursAllowedLabel() : string {
-    return MAX_EVENT_DURATION / 3600000 + "Hrs"
+    return MAX_EVENT_DURATION / Time.Hour + "Hrs"
   }
 
   function setError(key: string, description: string) {
@@ -189,7 +188,6 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
 
       setValues({
         start_at,
-        duration: MAX_EVENT_DURATION, // When change start date, set max duration
         recurrent_until,
         recurrent_monthday: null,
         recurrent_setpos: null,
@@ -227,8 +225,8 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
       0,
       finish_date.getTime() + finish_time.getTime() - event.start_at.getTime()
     )
-    // Change duration only if it's a different value and if it's less or equals to the max duration allowed
-    if (duration !== event.duration && duration <= MAX_EVENT_DURATION) {
+    // Change duration only if it's a different value and if it's less or equals to the max or previous duration or previous allowed
+    if (duration !== event.duration && duration <= Math.max(event.duration, MAX_EVENT_DURATION)) {
       setValues({ duration })
     }
   }
@@ -244,8 +242,8 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
       0,
       finish_date.getTime() + finish_time.getTime() - event.start_at.getTime()
     )
-    // Change duration only if it's a different value and if it's less or equals to the max duration allowed
-    if (duration !== event.duration && duration <= MAX_EVENT_DURATION) {
+    // Change duration only if it's a different value and if it's less or equals to the max or previous duration allowed
+    if (duration !== event.duration && duration <= Math.max(event.duration, MAX_EVENT_DURATION)) {
       setValues({ duration })
     }
   }

--- a/src/pages/submit.tsx
+++ b/src/pages/submit.tsx
@@ -481,7 +481,7 @@ export default function SubmitPage() {
                   <Divider size="tiny" />
                 </Grid.Column>
               </Grid.Row>
-              {/* TODO: since max duration is 24hrs, this needs to be rebuild or erased
+              {/* DEPRECATED // TODO: since max duration is 24hrs, this needs to be rebuild or erased
               <Grid.Row>
                 <Grid.Column mobile="16">
                   <Label style={{ cursor: "pointer" }}>

--- a/src/pages/submit.tsx
+++ b/src/pages/submit.tsx
@@ -481,6 +481,7 @@ export default function SubmitPage() {
                   <Divider size="tiny" />
                 </Grid.Column>
               </Grid.Row>
+              {/* TODO: since max duration is 24hrs, this needs to be rebuild or erased
               <Grid.Row>
                 <Grid.Column mobile="16">
                   <Label style={{ cursor: "pointer" }}>
@@ -499,7 +500,7 @@ export default function SubmitPage() {
                     />
                   </Label>
                 </Grid.Column>
-              </Grid.Row>
+                    </Grid.Row>*/}
               <Grid.Row>
                 <Grid.Column mobile="8">
                   <Field
@@ -539,7 +540,7 @@ export default function SubmitPage() {
                     name="finish_date"
                     type="date"
                     error={!!errors["finish_at"] || !!errors["finish_date"]}
-                    message={errors["finish_at"] || errors["finish_date"]}
+                    message={errors["finish_at"] || errors["finish_date"] || "Maximum allowed duration " + editActions.getMaxHoursAllowedLabel() }
                     value={editActions.getFinishDate()}
                     min={editActions.getStartDate()}
                     onChange={editActions.handleChange}
@@ -563,6 +564,9 @@ export default function SubmitPage() {
                     <Paragraph className="FieldNote">UTC</Paragraph>
                   </Grid.Column>
                 )}
+                <Grid.Column mobile="16">
+                  <Divider size="mini" />
+                </Grid.Column>
                 <Grid.Column mobile="8">
                   <SelectField
                     label="Repeat"


### PR DESCRIPTION
Updated the front-end by hiding the "All day event" switch. 
From the front-end only a maximum of 24 hours is allowed. 
Added validation in the backend when creating or updating an event.