### PR TITLE
fix: api events order next_start_at

### DIFF
--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -117,6 +117,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
 
     const start_at = Time.date(event.start_at)
     const finish_at = Time.date(event.finish_at)
+    // TODO: remove
     const duration =
       Number(event.duration) || finish_at.getTime() - start_at.getTime()
     const recurrent_dates =
@@ -199,7 +200,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
 
   static async getEvents(options: Partial<EventListOptions> = {}) {
     // return []
-    let orderBy = "e.next_finish_at"
+    let orderBy = "e.next_start_at"
     let orderDirection = "ASC"
     if (options.search) {
       orderBy = '"rank"'

--- a/src/hooks/useEventEditor.ts
+++ b/src/hooks/useEventEditor.ts
@@ -316,6 +316,7 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
         recurrent_monthday: null,
         recurrent_until: start_at.startOf("day").toDate(),
         recurrent_count: null,
+        duration: event.duration > Time.Day ? Time.Day : event.duration,
       })
     } else {
       setValues({


### PR DESCRIPTION
- api events order next_start_at. 
- Validate duration for recursive events
Related to #95 