### PR TITLE
feat: Move the Jump in button closer to the top on event pages

### DIFF
--- a/src/components/Event/EventModal/EventDetail/EventDetail.css
+++ b/src/components/Event/EventModal/EventDetail/EventDetail.css
@@ -14,7 +14,7 @@
 
 .EventDetail .EventDetail__Header {
   display: flex;
-  padding: 18px 24px;
+  padding: 18px 24px 0;
 }
 
 .EventDetail .EventDetail__Header .EventDetail__Header__Event {
@@ -117,6 +117,11 @@
 
 .EventDetail .EventDetail__Detail .EventDetail__Detail__Action {
   flex: 0 0 auto;
+}
+
+.EventDetail .AttendingButtons {
+  width: 100%;
+  max-width: none;
 }
 
 @media only screen and (max-width: 767px) {

--- a/src/components/Event/EventModal/EventDetail/EventDetail.tsx
+++ b/src/components/Event/EventModal/EventDetail/EventDetail.tsx
@@ -7,6 +7,7 @@ import Markdown from "decentraland-gatsby/dist/components/Text/Markdown"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
 import SubTitle from "decentraland-gatsby/dist/components/Text/SubTitle"
 import useAsyncMemo from "decentraland-gatsby/dist/hooks/useAsyncMemo"
+import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import { navigate } from "decentraland-gatsby/dist/plugins/intl"
 import Link from "decentraland-gatsby/dist/plugins/intl/Link"
 import prevent from "decentraland-gatsby/dist/utils/react/prevent"
@@ -24,6 +25,7 @@ import infoIcon from "../../../../images/secondary-info.svg"
 import pinIcon from "../../../../images/secondary-pin.svg"
 import locations from "../../../../modules/locations"
 import placesLocations from "../../../../modules/placesLocations"
+import AttendingButtons from "../../../Button/AttendingButtons"
 import JumpInButton from "../../../Button/JumpInPosition"
 import MenuIcon, { MenuIconItem } from "../../../MenuIcon/MenuIcon"
 import EventSection from "../../EventSection"
@@ -52,6 +54,7 @@ export type EventDetailProps = {
 }
 
 export default function EventDetail({ event, ...props }: EventDetailProps) {
+  const l = useFormatMessage()
   const now = Date.now()
   const { next_start_at } = event || { next_start_at: new Date(now) }
   const completed = event.finish_at.getTime() < now
@@ -81,13 +84,15 @@ export default function EventDetail({ event, ...props }: EventDetailProps) {
   )
 
   return (
-    <div className={"EventDetail"}>
+    <div className="EventDetail">
       <div className="EventDetail__Header">
         <DateBox date={next_start_at} utc={utc} />
         <div className="EventDetail__Header__Event">
           <SubTitle>{event.name}</SubTitle>
           <Paragraph className="EventDetail__Header__Event__By" secondary>
-            Public, Organized by <Link>{event.user_name || "Guest"}</Link>
+            {l("components.event.event_detail.public_organized_by", {
+              organizer: <Link>{event.user_name || "Guest"}</Link>,
+            })}
           </Paragraph>
         </div>
         {props.showEdit !== false && advance && (
@@ -124,6 +129,12 @@ export default function EventDetail({ event, ...props }: EventDetailProps) {
         )}
       </div>
 
+      {event.approved && (
+        <EventSection>
+          <AttendingButtons event={event} />
+        </EventSection>
+      )}
+
       {/* DESCRIPTION */}
       {props.showDescription !== false && <EventSection.Divider />}
       {props.showDescription !== false && (
@@ -132,7 +143,9 @@ export default function EventDetail({ event, ...props }: EventDetailProps) {
           <EventSection.Detail>
             {!event.description && (
               <Paragraph secondary={!event.description}>
-                <Italic>No description</Italic>
+                <Italic>
+                  {l("components.event.event_detail.no_description")}
+                </Italic>
               </Paragraph>
             )}
             {event.description && <Markdown children={event.description} />}
@@ -215,7 +228,9 @@ export default function EventDetail({ event, ...props }: EventDetailProps) {
               ))}
             {event.total_attendees === 0 && (
               <Paragraph secondary>
-                <Italic>Nobody confirmed yet</Italic>
+                <Italic>
+                  {l("components.event.event_detail.nobody_confirmed_yet")}
+                </Italic>
               </Paragraph>
             )}
           </EventSection.Detail>
@@ -252,7 +267,7 @@ export default function EventDetail({ event, ...props }: EventDetailProps) {
             )}
             {!event.contact && (
               <Paragraph secondary={!event.contact}>
-                <Italic>No contact</Italic>
+                <Italic>{l("components.event.event_detail.no_contact")}</Italic>
               </Paragraph>
             )}
           </EventSection.Detail>
@@ -271,7 +286,7 @@ export default function EventDetail({ event, ...props }: EventDetailProps) {
             {event.details && <Paragraph>{event.details}</Paragraph>}
             {!event.details && (
               <Paragraph secondary={!event.details}>
-                <Italic>No details</Italic>
+                <Italic>{l("components.event.event_detail.no_details")}</Italic>
               </Paragraph>
             )}
           </EventSection.Detail>

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -318,6 +318,13 @@
           "this_event_is_pending_approval": "This event is pending approval",
           "this_event_is_in_the_past": "This event has finished, can't be approve or rejected"
         }
+      },
+      "event_detail": {
+        "public_organized_by": "Public, Organized by {organizer}",
+        "no_description": "No description",
+        "nobody_confirmed_yet": "Nobody confirmed yet",
+        "no_contact": "No contact",
+        "no_details": "No details"
       }
     },
     "modal": {

--- a/src/pages/event.tsx
+++ b/src/pages/event.tsx
@@ -117,11 +117,6 @@ export default function EventPage() {
               {(event.approved || canApproveThisEvent) && (
                 <EventSection.Divider />
               )}
-              {event.approved && (
-                <EventSection>
-                  <AttendingButtons event={event} />
-                </EventSection>
-              )}
 
               {!event.approved && canApproveThisEvent && (
                 <EventSection>


### PR DESCRIPTION
Following this figma: https://www.figma.com/file/PBKW2xHkhT2M4iDCk7PZSq/Event-page-updates?node-id=2211-134&t=COLYS6nJerq2hxh2-4

<img width="899" alt="Screenshot 2023-05-04 at 16 30 44" src="https://user-images.githubusercontent.com/6572776/236310861-a160a095-493d-41ca-859a-92ec012e8ede.png">
<img width="916" alt="Screenshot 2023-05-04 at 16 30 50" src="https://user-images.githubusercontent.com/6572776/236310907-395c32f4-6da3-402e-bbeb-549394fa1ecf.png">
<img width="879" alt="Screenshot 2023-05-04 at 16 31 09" src="https://user-images.githubusercontent.com/6572776/236310916-d6045560-9014-4ffd-9e22-a8a7683051d4.png">
