### PR TITLE
fix: Add the /api path to the places API URL

### DIFF
--- a/src/api/Places.ts
+++ b/src/api/Places.ts
@@ -45,7 +45,7 @@ export type AggregatePlaceAttributes = PlaceAttributes & {
 }
 
 export default class Places extends API {
-  static Url = env("PLACES_API_URL", `https://places.decentraland.org`)
+  static Url = env("PLACES_API_URL", `https://places.decentraland.org/api`)
 
   static Cache = new Map<string, Places>()
 
@@ -58,7 +58,7 @@ export default class Places extends API {
   }
 
   static get() {
-    return this.from(`${env("PLACES_API_URL", this.Url)}/api`)
+    return this.from(env("PLACES_API_URL", this.Url))
   }
 
   static parsePlace(place: AggregatePlaceAttributes): AggregatePlaceAttributes {

--- a/src/config/dev.json
+++ b/src/config/dev.json
@@ -10,7 +10,7 @@
   "GATSBY_SEGMENT_KEY": "a4h4BC4dL1v7FhIQKKuPHEdZIiNRDVhc",
   "GATSBY_WEB_PUSH,_KEY": "BDcSrhptgGRYliwF8EtHUjKS7zwUAb7xiKZn2wsGfqDpWhXld5844vAKzzX6X8OvmcjGEfuoHvnYVKoijpL1D_w",
   "GATSBY_PLACES_URL": "https://decentraland.zone/places",
-  "GATSBY_PLACES_API_URL": "https://places.decentraland.zone",
+  "GATSBY_PLACES_API_URL": "https://places.decentraland.zone/api",
   "GATSBY_PROFILE_SITE_URL": "https://decentraland.org/profile",
   "GATSBY_SSO_URL": "https://id.decentraland.zone"
 }

--- a/src/config/local.json
+++ b/src/config/local.json
@@ -10,7 +10,7 @@
   "GATSBY_SEGMENT_KEY": "a4h4BC4dL1v7FhIQKKuPHEdZIiNRDVhc",
   "GATSBY_WEB_PUSH,_KEY": "BDcSrhptgGRYliwF8EtHUjKS7zwUAb7xiKZn2wsGfqDpWhXld5844vAKzzX6X8OvmcjGEfuoHvnYVKoijpL1D_w",
   "GATSBY_PLACES_URL": "https://places.decentraland.org",
-  "GATSBY_PLACES_API_URL": "https://places.decentraland.org",
+  "GATSBY_PLACES_API_URL": "https://places.decentraland.org/api",
   "GATSBY_PROFILE_SITE_URL": "https://profile.decentraland.org",
   "GATSBY_SSO_URL": "https://id.decentraland.zone",
   "GATSBY_ADMIN_ADDRESSES": "0xd9B96B5dC720fC52BedE1EC3B40A930e15F70Ddd"

--- a/src/config/prod.json
+++ b/src/config/prod.json
@@ -10,7 +10,7 @@
   "GATSBY_SEGMENT_KEY": "d4skMcpfGrW2tP8FGTDtCIetsp3W7Boo",
   "GATSBY_WEB_PUSH_KEY": "BDcSrhptgGRYliwF8EtHUjKS7zwUAb7xiKZn2wsGfqDpWhXld5844vAKzzX6X8OvmcjGEfuoHvnYVKoijpL1D_w",
   "GATSBY_PLACES_URL": "https://places.decentraland.org",
-  "GATSBY_PLACES_API_URL": "https://places.decentraland.org",
+  "GATSBY_PLACES_API_URL": "https://places.decentraland.org/api",
   "GATSBY_PROFILE_SITE_URL": "https://profile.decentraland.org",
   "GATSBY_SSO_URL": "https://id.decentraland.org"
 }


### PR DESCRIPTION
This PR changes the `PLACES_API_URL` to contain the `/api` path, representing the API URL better.