### PR TITLE
feat: Use auth page when viewing a non authorized site

### DIFF
--- a/src/pages/pending.tsx
+++ b/src/pages/pending.tsx
@@ -9,6 +9,7 @@ import Link from "decentraland-gatsby/dist/components/Text/Link"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
 import SubTitle from "decentraland-gatsby/dist/components/Text/SubTitle"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
+import { DappsFeatureFlags } from "decentraland-gatsby/dist/context/FeatureFlag/types"
 import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import { navigate } from "decentraland-gatsby/dist/plugins/intl"
@@ -19,7 +20,6 @@ import { Loader } from "decentraland-ui/dist/components/Loader/Loader"
 import { SignIn } from "decentraland-ui/dist/components/SignIn/SignIn"
 
 import EventCard from "../components/Event/EventCard/EventCard"
-import EventModal from "../components/Event/EventModal/EventModal"
 import Navigation, { NavigationTab } from "../components/Layout/Navigation"
 import EnabledNotificationModal from "../components/Modal/EnabledNotificationModal"
 import {
@@ -37,6 +37,7 @@ export default function MyEventsPage() {
   const l = useFormatMessage()
   const location = useLocation()
   const [ff] = useFeatureFlagContext()
+  const isAuthDappEnabled = ff.enabled(DappsFeatureFlags.AuthDappEnabled)
   const params = new URLSearchParams(location.search)
   const [account, accountState] = useAuthContext()
   const [eventList, eventsState] = useEventsContext()
@@ -99,7 +100,9 @@ export default function MyEventsPage() {
         <Container>
           <SignIn
             isConnecting={accountState.loading}
-            onConnect={() => accountState.select()}
+            onConnect={
+              isAuthDappEnabled ? accountState.authorize : accountState.select
+            }
           />
         </Container>
       </>

--- a/src/pages/schedules.tsx
+++ b/src/pages/schedules.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useMemo, useState } from "react"
+import React from "react"
 
 import MaintenancePage from "decentraland-gatsby/dist/components/Layout/MaintenancePage"
 import NotFound from "decentraland-gatsby/dist/components/Layout/NotFound"
 import Divider from "decentraland-gatsby/dist/components/Text/Divider"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
-import Avatar from "decentraland-gatsby/dist/components/User/Avatar"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
+import { DappsFeatureFlags } from "decentraland-gatsby/dist/context/FeatureFlag/types"
 import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
 import useAsyncMemo from "decentraland-gatsby/dist/hooks/useAsyncMemo"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
@@ -38,6 +38,7 @@ export default function SettingsPage() {
   const [account, accountState] = useAuthContext()
   const [settings, settingsState] = useProfileSettingsContext()
   const [ff] = useFeatureFlagContext()
+  const isAuthDappEnabled = ff.enabled(DappsFeatureFlags.AuthDappEnabled)
   const [schedules, schedulesState] = useAsyncMemo(
     async () => {
       const schedules = await Events.get().getSchedules()
@@ -71,7 +72,9 @@ export default function SettingsPage() {
         <Container>
           <SignIn
             isConnecting={accountState.loading || settingsState.loading}
-            onConnect={() => accountState.select()}
+            onConnect={
+              isAuthDappEnabled ? accountState.authorize : accountState.select
+            }
           />
         </Container>
       </>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -5,6 +5,7 @@ import { Helmet } from "react-helmet"
 import MaintenancePage from "decentraland-gatsby/dist/components/Layout/MaintenancePage"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
+import { DappsFeatureFlags } from "decentraland-gatsby/dist/context/FeatureFlag/types"
 import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
 import useCountdown from "decentraland-gatsby/dist/hooks/useCountdown"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
@@ -33,6 +34,7 @@ export default function SettingsPage() {
   const [account, accountState] = useAuthContext()
   const [settings, state] = useProfileSettingsContext()
   const [ff] = useFeatureFlagContext()
+  const isAuthDappEnabled = ff.enabled(DappsFeatureFlags.AuthDappEnabled)
   const [email, setEmail] = useState(settings.email)
   const currentEmailChanged = email !== settings.email
   const currentEmailIsValid = useMemo(() => isEmail(email || ""), [email])
@@ -122,7 +124,9 @@ export default function SettingsPage() {
         <Container>
           <SignIn
             isConnecting={accountState.loading}
-            onConnect={() => accountState.select()}
+            onConnect={
+              isAuthDappEnabled ? accountState.authorize : accountState.select
+            }
           />
         </Container>
       </>

--- a/src/pages/submit/schedule.tsx
+++ b/src/pages/submit/schedule.tsx
@@ -6,6 +6,8 @@ import { useLocation } from "@gatsbyjs/reach-router"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
 import Title from "decentraland-gatsby/dist/components/Text/Title"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
+import { DappsFeatureFlags } from "decentraland-gatsby/dist/context/FeatureFlag/types"
+import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
 import useAsyncTask from "decentraland-gatsby/dist/hooks/useAsyncTask"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import usePatchState from "decentraland-gatsby/dist/hooks/usePatchState"
@@ -24,7 +26,6 @@ import SelectionLabel from "semantic-ui-react/dist/commonjs/elements/Label"
 import Events, { EditSchedule } from "../../api/Events"
 import AddCoverButton from "../../components/Button/AddCoverButton"
 import ImageInput from "../../components/Form/ImageInput"
-import Label from "../../components/Form/Label"
 import Textarea from "../../components/Form/Textarea"
 import ItemLayout from "../../components/Layout/ItemLayout"
 import {
@@ -56,7 +57,9 @@ export default function ScheduleEditPage() {
   const l = useFormatMessage()
   const [state, patchState] = usePatchState<ScheduleEditPageState>({})
   const [account, accountState] = useAuthContext()
+  const [ff] = useFeatureFlagContext()
   const location = useLocation()
+  const isAuthDappEnabled = ff.enabled(DappsFeatureFlags.AuthDappEnabled)
   const params = new URLSearchParams(location.search)
 
   const [editing, editActions] = useScheduleEditor()
@@ -230,7 +233,9 @@ export default function ScheduleEditPage() {
         {!loading && (!account || accountState.loading) && (
           <SignIn
             isConnecting={accountState.loading}
-            onConnect={() => accountState.select()}
+            onConnect={
+              isAuthDappEnabled ? accountState.authorize : accountState.select
+            }
           />
         )}
         {!loading && account && (

--- a/src/pages/submit/user.tsx
+++ b/src/pages/submit/user.tsx
@@ -5,6 +5,8 @@ import NotFound from "decentraland-gatsby/dist/components/Layout/NotFound"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
 import Avatar from "decentraland-gatsby/dist/components/User/Avatar"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
+import { DappsFeatureFlags } from "decentraland-gatsby/dist/context/FeatureFlag/types"
+import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
 import useAsyncMemo from "decentraland-gatsby/dist/hooks/useAsyncMemo"
 import useAsyncTask from "decentraland-gatsby/dist/hooks/useAsyncTask"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
@@ -37,6 +39,8 @@ export default function SettingsPage() {
   const l = useFormatMessage()
   const [account, accountState] = useAuthContext()
   const [settings, settingsState] = useProfileSettingsContext()
+  const [ff] = useFeatureFlagContext()
+  const isAuthDappEnabled = ff.enabled(DappsFeatureFlags.AuthDappEnabled)
   const [value, setValue] = useState("")
   const handleChangeValue = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.value),
@@ -118,7 +122,9 @@ export default function SettingsPage() {
         <Container>
           <SignIn
             isConnecting={accountState.loading || settingsState.loading}
-            onConnect={() => accountState.select()}
+            onConnect={
+              isAuthDappEnabled ? accountState.authorize : accountState.select
+            }
           />
         </Container>
       </>

--- a/src/pages/user.tsx
+++ b/src/pages/user.tsx
@@ -6,6 +6,7 @@ import NotFound from "decentraland-gatsby/dist/components/Layout/NotFound"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
 import Avatar from "decentraland-gatsby/dist/components/User/Avatar"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
+import { DappsFeatureFlags } from "decentraland-gatsby/dist/context/FeatureFlag/types"
 import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
 import useAsyncMemo from "decentraland-gatsby/dist/hooks/useAsyncMemo"
 import useAsyncTask from "decentraland-gatsby/dist/hooks/useAsyncTask"
@@ -43,6 +44,7 @@ export default function SettingsPage() {
   const [account, accountState] = useAuthContext()
   const [settings, settingsState] = useProfileSettingsContext()
   const [ff] = useFeatureFlagContext()
+  const isAuthDappEnabled = ff.enabled(DappsFeatureFlags.AuthDappEnabled)
   const [value, setValue] = useState("")
   const handleChangeValue = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.value),
@@ -128,7 +130,9 @@ export default function SettingsPage() {
         <Container>
           <SignIn
             isConnecting={accountState.loading || settingsState.loading}
-            onConnect={() => accountState.select()}
+            onConnect={
+              isAuthDappEnabled ? accountState.authorize : accountState.select
+            }
           />
         </Container>
       </>

--- a/src/pages/users.tsx
+++ b/src/pages/users.tsx
@@ -6,6 +6,7 @@ import Divider from "decentraland-gatsby/dist/components/Text/Divider"
 import Paragraph from "decentraland-gatsby/dist/components/Text/Paragraph"
 import Avatar from "decentraland-gatsby/dist/components/User/Avatar"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
+import { DappsFeatureFlags } from "decentraland-gatsby/dist/context/FeatureFlag/types"
 import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
 import useAsyncMemo from "decentraland-gatsby/dist/hooks/useAsyncMemo"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
@@ -45,6 +46,7 @@ export default function SettingsPage() {
   const [account, accountState] = useAuthContext()
   const [settings, settingsState] = useProfileSettingsContext()
   const [ff] = useFeatureFlagContext()
+  const isAuthDappEnabled = ff.enabled(DappsFeatureFlags.AuthDappEnabled)
   const [filter, setFilter] = useState("")
   const handleChangeFilter = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) =>
@@ -103,7 +105,9 @@ export default function SettingsPage() {
         <Container>
           <SignIn
             isConnecting={accountState.loading || settingsState.loading}
-            onConnect={() => accountState.select()}
+            onConnect={
+              isAuthDappEnabled ? accountState.authorize : accountState.select
+            }
           />
         </Container>
       </>


### PR DESCRIPTION
This PR changes the way the connect button in the `SignIn` component works by redirecting the user to the auth site when the user is not logged in and the feature flag is active.