### PR TITLE
feat: Change how featured events are displayed

### DIFF
--- a/src/components/Event/CarouselEvents/CarouselEvents.tsx
+++ b/src/components/Event/CarouselEvents/CarouselEvents.tsx
@@ -29,6 +29,7 @@ import "./CarouselEvents.css"
 
 export type CarouselEventsProps = {
   loading?: boolean
+  hideGoToSchedule?: boolean
   events?: SessionEventAttributes[]
   schedule?: ScheduleAttributes
 }
@@ -103,18 +104,21 @@ export const CarouselEvents = React.memo((props: CarouselEventsProps) => {
           items={mainEvents}
           component={CarouselEventItem}
         />
-        {!props.loading && schedule && !schedule?.theme && (
-          <div className="carousel-events__action-wrapper">
-            <Button
-              primary
-              as="a"
-              href={withPrefix(locations.schedule(schedule.id))}
-              onClick={handleClickFullSchedule}
-            >
-              Full Schedule
-            </Button>
-          </div>
-        )}
+        {!props.loading &&
+          schedule &&
+          !schedule?.theme &&
+          !props.hideGoToSchedule && (
+            <div className="carousel-events__action-wrapper">
+              <Button
+                primary
+                as="a"
+                href={withPrefix(locations.schedule(schedule.id))}
+                onClick={handleClickFullSchedule}
+              >
+                Full Schedule
+              </Button>
+            </div>
+          )}
       </Container>
     </ContainerWrapper>
   )

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -4,7 +4,6 @@ import once from "decentraland-gatsby/dist/utils/function/once"
 
 import Events from "../api/Events"
 import { SessionEventAttributes } from "../entities/Event/types"
-import { EventCategoryAttributes } from "../entities/EventCategory/types"
 import { ScheduleAttributes } from "../entities/Schedule/types"
 import locations from "./locations"
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,6 @@ import { useLocation } from "@gatsbyjs/reach-router"
 import MaintenancePage from "decentraland-gatsby/dist/components/Layout/MaintenancePage"
 import useAuthContext from "decentraland-gatsby/dist/context/Auth/useAuthContext"
 import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/useFeatureFlagContext"
-import useAsyncMemo from "decentraland-gatsby/dist/hooks/useAsyncMemo"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import { navigate } from "decentraland-gatsby/dist/plugins/intl"
 import { Container } from "decentraland-ui/dist/components/Container/Container"
@@ -24,8 +23,6 @@ import {
 } from "../context/Event"
 import { useProfileSettingsContext } from "../context/ProfileSetting"
 import { SessionEventAttributes } from "../entities/Event/types"
-import { getCurrentSchedules } from "../entities/Schedule/utils"
-import { getSchedules } from "../modules/events"
 import { Flags } from "../modules/features"
 import locations, { toEventFilters } from "../modules/locations"
 
@@ -41,7 +38,6 @@ export default function IndexPage() {
   const l = useFormatMessage()
   const [, accountState] = useAuthContext()
   const location = useLocation()
-  const [schedules] = useAsyncMemo(getSchedules)
   const params = useMemo(
     () => new URLSearchParams(location.search),
     [location.search]
@@ -51,11 +47,6 @@ export default function IndexPage() {
   const [all, state] = useEventsContext()
   const events = useEventSorter(all, settings)
   const loading = accountState.loading || state.loading
-
-  const currentSchedule = useMemo(
-    () => getCurrentSchedules(schedules),
-    [schedules]
-  )
 
   const filters = useMemo(() => toEventFilters(params), [params])
   const [enabledNotification, setEnabledNotification] = useState(false)
@@ -106,7 +97,6 @@ export default function IndexPage() {
 
       <CarouselEvents
         events={filters.search ? empty : events}
-        schedule={currentSchedule}
         loading={loading}
       />
 

--- a/src/pages/schedule.tsx
+++ b/src/pages/schedule.tsx
@@ -13,10 +13,12 @@ import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import TokenList from "decentraland-gatsby/dist/utils/dom/TokenList"
 import { Container } from "decentraland-ui/dist/components/Container/Container"
 
+import { CarouselEvents } from "../components/Event/CarouselEvents/CarouselEvents"
 import { ListEvents } from "../components/Event/ListEvents/ListEvents"
 import Navigation, { NavigationTab } from "../components/Layout/Navigation"
 import EnabledNotificationModal from "../components/Modal/EnabledNotificationModal"
 import { useEventSchedule, useEventsContext } from "../context/Event"
+import { SessionEventAttributes } from "../entities/Event/types"
 import { ScheduleTheme } from "../entities/Schedule/types"
 import mvfwLogo from "../images/mvfw.svg"
 import mvmfImage from "../images/mvmf.jpg"
@@ -102,7 +104,12 @@ export default function IndexPage() {
         onClose={() => setEnabledNotification(false)}
       />
       <Navigation activeTab={schedule && NavigationTab.Schedule} search />
-
+      <CarouselEvents
+        events={events}
+        schedule={schedule}
+        loading={loading}
+        hideGoToSchedule
+      />
       <div
         className={TokenList.join([
           "scheduled-events",


### PR DESCRIPTION
This PR changes how we show events in the events site. The main site will show all events, highlighting them without the need to highlight the scheduled ones and the schedule site will show a slider with the highlighted events for the scheduled event.

Index site
![Screenshot 2024-03-12 at 17 04 48](https://github.com/decentraland/events/assets/1120791/7f84c8e6-20ab-4d1a-9151-8d56b169b1d2)

Schedule site
![Screenshot 2024-03-12 at 17 04 56](https://github.com/decentraland/events/assets/1120791/91ed36e2-b2ed-4a94-9449-b9e3ca069615)
