### PR TITLE
fix: add '?' to deep link

### DIFF
--- a/src/modules/desktop.ts
+++ b/src/modules/desktop.ts
@@ -55,7 +55,7 @@ export const launchDesktopApp = async (options: {
     customProtocolParams.push(`realm=${options.realm}`)
   }
 
-  const customProtocolTarget = `decentraland://${customProtocolParams.join(
+  const customProtocolTarget = `decentraland://?${customProtocolParams.join(
     "&"
   )}`
 


### PR DESCRIPTION
Add a `?` at the beginning of the deep link