### PR TITLE
feat: Add a new query param positions

### DIFF
--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -222,6 +222,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       orderDirection = options.order === "asc" ? "ASC" : "DESC"
     }
 
+    // Prioritizes "x" && "y" options params over positions
     let coordinatesFilter = ""
     if (
       !Number.isFinite(options.x) &&

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -223,15 +223,15 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     }
 
     // Prioritizes "x" && "y" options params over positions
-    let coordinatesFilter = ""
+    let positionsFilter = ""
     if (
       !Number.isFinite(options.x) &&
       !Number.isFinite(options.y) &&
       options.positions &&
       options.positions.length > 0
     ) {
-      coordinatesFilter = options.positions
-        .map((position) => `ARRAY[${position.join(",")}]`)
+      positionsFilter = options.positions
+        .map((position) => `(${position.join(",")})`)
         .join(",")
     }
 
@@ -290,8 +290,8 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
           SQL`AND e.x = ${options.x} AND e.y = ${options.y}`
         )}
         ${conditional(
-          !!coordinatesFilter,
-          SQL`AND e.coordinates IN (${SQL.raw(coordinatesFilter)})`
+          !!positionsFilter,
+          SQL`AND (e.x, e.y) = ANY(Array[${SQL.raw(positionsFilter)}])`
         )}
         ${conditional(
           !!options.estate_id,

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -222,6 +222,18 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       orderDirection = options.order === "asc" ? "ASC" : "DESC"
     }
 
+    let coordinatesFilter = ""
+    if (
+      !Number.isFinite(options.x) &&
+      !Number.isFinite(options.y) &&
+      options.positions &&
+      options.positions.length > 0
+    ) {
+      coordinatesFilter = options.positions
+        .map((position) => `ARRAY[${position.join(",")}]`)
+        .join(",")
+    }
+
     const query = SQL`
       SELECT
         e.*
@@ -275,6 +287,10 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         ${conditional(
           Number.isFinite(options.x) && Number.isFinite(options.y),
           SQL`AND e.x = ${options.x} AND e.y = ${options.y}`
+        )}
+        ${conditional(
+          !!coordinatesFilter,
+          SQL`AND e.coordinates IN (${SQL.raw(coordinatesFilter)})`
         )}
         ${conditional(
           !!options.estate_id,

--- a/src/entities/Event/routes/getEventList.ts
+++ b/src/entities/Event/routes/getEventList.ts
@@ -64,6 +64,27 @@ export async function getEventList(req: WithAuth) {
     }
   }
 
+  if (!!query.positions && query.positions.length > 0) {
+    options.positions = []
+
+    for (const position of query.positions) {
+      const [x, y] = position.split(",").slice(0, 2).map(Number) as [
+        number,
+        number
+      ]
+
+      if (
+        !Number.isFinite(x) ||
+        !Number.isFinite(y) ||
+        !isInsideWorldLimits(x, y)
+      ) {
+        return []
+      }
+
+      options.positions.push([x, y])
+    }
+  }
+
   if (query.estate_id) {
     const estateId = Number(query.estate_id)
     if (estateId !== null && Number.isFinite(estateId)) {

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -38,6 +38,12 @@ export const getEventListQuery: AjvObjectSchema = {
       pattern: "^-?\\d{1,3},-?\\d{1,3}$",
       description: "Filter events that will happend in a specific position",
     },
+    positions: {
+      type: "array",
+      maxItems: 1000,
+      items: { type: "string", pattern: "^-?\\d{1,3},-?\\d{1,3}$" },
+      description: "Filter places in specific positions",
+    },
     estate_id: {
       type: "string",
       format: "int",

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -174,6 +174,7 @@ export type EventListParams = {
   list?: EventListType
   creator?: string
   position?: string
+  positions?: string[]
   estate_id?: string
   only_attendee?: boolean
   search?: string
@@ -191,6 +192,7 @@ export type EventListOptions = {
   creator?: string
   x?: number
   y?: number
+  positions?: number[][]
   estate_id?: string
   only_attendee?: boolean
   search?: string


### PR DESCRIPTION
This PR adds new queryParam positions to filter events passing multiple coordinates.

ex: `https://events.decentraland.org/api/events?positions[]=109,49&positions[]=-62,128&positions[]=5,23`


Closes https://github.com/decentraland/events/issues/699