### PR TITLE
chore: upgrade navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "cssnano": "^5.0.10",
         "dcl-catalyst-client": "^21.5.0",
         "decentraland-gatsby": "^6.15.0",
+        "decentraland-ui": "^6.12.0",
         "es6-shim": "^0.35.6",
         "express-fileupload": "^1.2.1",
         "gatsby": "^4.23.0",
@@ -17795,9 +17796,10 @@
       }
     },
     "node_modules/decentraland-ui": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-6.11.0.tgz",
-      "integrity": "sha512-2CNlYcNh5JvWEYeqw+jxOtPngXP6cnEHs04Pv+C3ypBAdlNJJzay2rlCicY7drBZYf6MTk5mQQb/tySE+h3okA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-6.12.0.tgz",
+      "integrity": "sha512-pc9tw/LwB0Cuzknb+QIIUuyg1It9l3KHWjgGBN6UIp24y1Tr0doEK5M45RBtV/e40qHL8RjgsXZyUW8W5CCMkA==",
+      "license": "MIT",
       "dependencies": {
         "@dcl/schemas": "^13.9.0",
         "@dcl/ui-env": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cssnano": "^5.0.10",
     "dcl-catalyst-client": "^21.5.0",
     "decentraland-gatsby": "^6.15.0",
+    "decentraland-ui": "^6.12.0",
     "es6-shim": "^0.35.6",
     "express-fileupload": "^1.2.1",
     "gatsby": "^4.23.0",


### PR DESCRIPTION
Upgrade `decentraland-ui` to have the new Navbar with extra button configurable via Contentful:

<img width="764" alt="Screenshot 2024-11-13 at 11 40 04 AM" src="https://github.com/user-attachments/assets/a54f71fb-1b7b-418c-a1a7-85c82850e878">
