### PR TITLE
chore: Upgrade decentraland-gatsby package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "core-js": "^3.22.2",
         "cssnano": "^5.0.10",
         "dcl-catalyst-client": "^21.5.0",
-        "decentraland-gatsby": "^6.45.0",
+        "decentraland-gatsby": "^6.45.1",
         "decentraland-ui": "^6.14.0",
         "es6-shim": "^0.35.6",
         "express-fileupload": "^1.2.1",
@@ -19996,9 +19996,9 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "6.45.0",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-6.45.0.tgz",
-      "integrity": "sha512-TGBvZjzmZFKQ1akIw9mHMuUo059tfuUAaK72hNtc+HOYeJp4gCMjS8te+yIWTnhlPlkCelYQbsRnPz8qpZ+RfA==",
+      "version": "6.45.1",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-6.45.1.tgz",
+      "integrity": "sha512-9PTNuYC6yc7cyHo30UprDG6Q08iACFDQ4NJGvlYbUHl2gIIsTruzlS9NNiX67BeQuf2bNFaihnVHHUDM4LnZUA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "core-js": "^3.22.2",
     "cssnano": "^5.0.10",
     "dcl-catalyst-client": "^21.5.0",
-    "decentraland-gatsby": "^6.45.0",
+    "decentraland-gatsby": "^6.45.1",
     "decentraland-ui": "^6.14.0",
     "es6-shim": "^0.35.6",
     "express-fileupload": "^1.2.1",


### PR DESCRIPTION
This PR fixes the JSON parsing for the FF launcher-links variants