### PR TITLE
feat: community events retrieval

### DIFF
--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -230,12 +230,19 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         !!options.world_names,
         SQL`AND e.server = ANY(${options.world_names})`
       ),
+      // Handle places_ids and community_id with OR logic when both are present
       conditional(
-        !!options.places_ids,
+        !!options.places_ids && !!options.community_id,
+        SQL`AND (e.place_id = ANY(${options.places_ids}) OR e.community_id = ${options.community_id})`
+      ),
+      // Handle places_ids only when community_id is not present
+      conditional(
+        !!options.places_ids && !options.community_id,
         SQL`AND e.place_id = ANY(${options.places_ids})`
       ),
+      // Handle community_id only when places_ids is not present
       conditional(
-        !!options.community_id,
+        !options.places_ids && !!options.community_id,
         SQL`AND e.community_id = ${options.community_id}`
       ),
     ].filter((condition) => !!condition.text)

--- a/src/entities/Event/routes/index.ts
+++ b/src/entities/Event/routes/index.ts
@@ -28,7 +28,7 @@ export default routes((router) => {
   )
   router.post("/events", withAuth, withAuthProfile(), handle(createEvent))
   router.post(
-    "/events/by-places",
+    "/events/search",
     withPublicAccess,
     withOptionalAuth,
     handle(getEventList as any)

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -401,6 +401,28 @@ export const eventListByPlacesResponseSchema = apiResultSchema({
   },
 } as AjvObjectSchema)
 
+export const getEventListByPlacesBodySchema = {
+  type: "object",
+  description: "Request body for filtering events by places and/or community",
+  additionalProperties: false,
+  properties: {
+    placeIds: {
+      type: "array",
+      description: "Array of place IDs to filter events by",
+      items: {
+        type: "string",
+        format: "uuid",
+      },
+      maxItems: 100,
+    },
+    communityId: {
+      type: "string",
+      format: "uuid",
+      description: "Community ID to filter events by (optional)",
+    },
+  },
+} as AjvObjectSchema
+
 export const newEventSchema = {
   type: "object",
   additionalProperties: false,

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -43,9 +43,9 @@ export default function DocsPage() {
         </ApiCard>
 
         <ApiCard
-          id="get-events-by-places"
+          id="get-events-search"
           method="POST"
-          path="/api/events/by-places"
+          path="/api/events/search"
           description="Returns the list of events filtered by place IDs and/or community ID"
         >
           <ApiDetails

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -9,6 +9,7 @@ import {
   eventListByPlacesResponseSchema,
   eventListResponseSchema,
   eventResponseSchema,
+  getEventListByPlacesBodySchema,
   getEventListQuery,
   getEventParamsSchema,
 } from "../entities/Event/schemas"
@@ -45,9 +46,14 @@ export default function DocsPage() {
           id="get-events-by-places"
           method="POST"
           path="/api/events/by-places"
-          description="Returns the list of the upcoming events by places"
+          description="Returns the list of events filtered by place IDs and/or community ID"
         >
-          <ApiDetails title="Request" cors="*" query={getEventListQuery} />
+          <ApiDetails
+            title="Request"
+            cors="*"
+            query={getEventListQuery}
+            body={getEventListByPlacesBodySchema}
+          />
           <ApiDetails title="Response" body={eventListByPlacesResponseSchema} />
         </ApiCard>
 


### PR DESCRIPTION
# Update getEventList endpoint with structured body and OR logic

## Summary
Updated `/api/events/search` (renamed from `/api/events/by-places`) to accept structured body format and implement OR logic for filtering by place IDs and/or community ID.

## Changes

### API
- **New Endpoint**: `/api/events/search` (was `/api/events/by-places`)
- **New Body Format**: `{ placeIds: [...], communityId?: string }` (was plain array)
- **OR Logic**: Events returned if matching place IDs OR community ID (was AND)
- **No Duplicates**: Events matching both conditions returned once

### Code
- **`index.ts`**: Renamed route from `/events/by-places` to `/events/search`
- **`getEventList.ts`**: Updated body parsing, removed array compatibility
- **`model.ts`**: Added OR logic in SQL: `(place_id IN (...) OR community_id = ...)`
- **`schemas.ts`**: Added body schema validation
- **`docs.tsx`**: Updated API documentation and endpoint path