### PR TITLE
fix: Places API url resolution

### DIFF
--- a/src/api/Places.ts
+++ b/src/api/Places.ts
@@ -45,7 +45,10 @@ export type AggregatePlaceAttributes = PlaceAttributes & {
 }
 
 export default class Places extends API {
-  static Url = env("PLACES_API_URL", `https://places.decentraland.org/api`)
+  static Url = env(
+    "GATSBY_PLACES_API_URL",
+    `https://places.decentraland.org/api`
+  )
 
   static Cache = new Map<string, Places>()
 


### PR DESCRIPTION
Zone environment was using `.org` TLD for Places API integration because the env var was incorrectly referenced.