### PR TITLE
fix: communities' dropdown to be able to unselect community

### DIFF
--- a/src/modules/communities.ts
+++ b/src/modules/communities.ts
@@ -17,9 +17,19 @@ export const getCommunitiesByOwner = async (
 export const getCommunitiesOptions = (
   communities: AggregateCommunityAttributes[]
 ) => {
-  return communities.map((community) => ({
+  const communityOptions = communities.map((community) => ({
     key: community.id,
     text: community.name,
     value: community.id,
   }))
+
+  // Add "None" option at the beginning to unselect the community
+  return [
+    {
+      key: "none",
+      text: "None",
+      value: undefined,
+    },
+    ...communityOptions,
+  ]
 }

--- a/src/pages/submit/index.tsx
+++ b/src/pages/submit/index.tsx
@@ -312,7 +312,7 @@ export default function SubmitPage() {
           userCommunities && userCommunities.length > 0
             ? communityOptions.find(
                 (option) => option.value === original.community_id
-              )?.value || null
+              )?.value || undefined
             : original.community_id,
       })
     } else if (communityFromUrl && editing.community_id === null) {
@@ -1159,7 +1159,8 @@ export default function SubmitPage() {
                   />
                 </Grid.Column>
               </Grid.Row>
-              {communityOptions.length > 0 && (
+              {/* Community's None option will always be available */}
+              {communityOptions.length > 1 && (
                 <Grid.Row>
                   <Grid.Column mobile="16">
                     <SelectField


### PR DESCRIPTION
This PR fixes the communities' dropdown to have a `None` option used to unlink the community once already selected in the Events view.