### PR TITLE
fix: Update Gatsby Task Manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "core-js": "^3.22.2",
         "cssnano": "^5.0.10",
         "dcl-catalyst-client": "^21.5.0",
-        "decentraland-gatsby": "^6.54.0",
+        "decentraland-gatsby": "^7.0.0",
         "es6-shim": "^0.35.6",
         "express-fileupload": "^1.2.1",
         "gatsby": "^4.23.0",
@@ -21106,9 +21106,9 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "6.54.0",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-6.54.0.tgz",
-      "integrity": "sha512-dt8q1/xRHJ6Re6hyWPSyl0gTctYTTm7ggnkmv7H3kX14jiZDy6FDGASx4BEIBwM2agD7nAeMtJy1tEMRokLV0g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-7.0.0.tgz",
+      "integrity": "sha512-q/2NEjrIZbkTzAQUxBYSwzXw1cCSsFwN3KFdTGH/AAY2gG/+UgXKGRRNDxejN9RpPGg8Gze+X0fOwQlMTrbalQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "core-js": "^3.22.2",
     "cssnano": "^5.0.10",
     "dcl-catalyst-client": "^21.5.0",
-    "decentraland-gatsby": "^6.54.0",
+    "decentraland-gatsby": "^7.0.0",
     "es6-shim": "^0.35.6",
     "express-fileupload": "^1.2.1",
     "gatsby": "^4.23.0",


### PR DESCRIPTION
This PR updates the `decentraland-gatsby-dependency` to work with the new task manager.