### PR TITLE
feat: add highlighted event filtering to event queries

### DIFF
--- a/src/entities/Event/model.test.ts
+++ b/src/entities/Event/model.test.ts
@@ -173,4 +173,60 @@ describe("EventModel.buildEventFilterConditions", () => {
       })
     })
   })
+
+  describe("when list type filters are provided", () => {
+    const HIGHLIGHTED_FILTER_REGEX = /e\.highlighted\s+IS\s+TRUE/i
+    const ACTIVE_FILTER_REGEX = /e\.next_finish_at\s*>\s*now\(\)/i
+    const LIVE_FILTER_REGEX =
+      /e\.next_finish_at\s*>\s*now\(\)\s*AND\s*e\.next_start_at\s*<\s*now\(\)/i
+    const UPCOMING_FILTER_REGEX =
+      /e\.next_finish_at\s*>\s*now\(\)\s*AND\s*e\.next_start_at\s*>\s*now\(\)/i
+
+    function hasHighlightedCondition(conditions: SQLCondition[]): boolean {
+      return conditions.some((condition) =>
+        HIGHLIGHTED_FILTER_REGEX.test(condition.text)
+      )
+    }
+
+    describe("and list is Highlight", () => {
+      let options: Partial<EventListOptions>
+
+      beforeEach(() => {
+        options = {
+          list: EventListType.Highlight,
+        }
+      })
+
+      it("generates a highlighted filter condition", () => {
+        const conditions = buildEventFilterConditions(options)
+
+        expect(hasHighlightedCondition(conditions)).toBe(true)
+      })
+
+      it("also filters for active events (next_finish_at > now())", () => {
+        const conditions = buildEventFilterConditions(options)
+        const hasActiveFilter = conditions.some((condition) =>
+          /e\.next_finish_at\s*>\s*now\(\)/.test(condition.text)
+        )
+
+        expect(hasActiveFilter).toBe(true)
+      })
+    })
+
+    describe("and list is Active", () => {
+      let options: Partial<EventListOptions>
+
+      beforeEach(() => {
+        options = {
+          list: EventListType.Active,
+        }
+      })
+
+      it("does not generate a highlighted filter condition", () => {
+        const conditions = buildEventFilterConditions(options)
+
+        expect(hasHighlightedCondition(conditions)).toBe(false)
+      })
+    })
+  })
 })

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -192,6 +192,10 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         options.list === EventListType.Upcoming,
         SQL`AND e.next_finish_at > now() AND e.next_start_at > now()`
       ),
+      conditional(
+        options.list === EventListType.Highlight,
+        SQL`AND e.highlighted IS TRUE AND e.next_finish_at > now()`
+      ),
       conditional(!!options.search, SQL`AND "rank" > 0`),
       conditional(
         !!options.creator,

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -88,6 +88,10 @@ export const getEventListQuery: AjvObjectSchema = {
           enum: ["upcoming"],
           description: "Only future events",
         },
+        {
+          enum: ["highlight"],
+          description: "Only highlighted events",
+        },
       ],
     },
     order: {

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -172,6 +172,7 @@ export enum EventListType {
   Live = "live",
   Upcoming = "upcoming",
   Relevance = "relevance",
+  Highlight = "highlight",
 }
 
 export type EventListParams = {


### PR DESCRIPTION
- Introduced a new filter option for highlighted events in the EventModel, allowing for SQL conditions to retrieve only highlighted events.
- Updated the EventListType enum to include a Highlight option.
- Enhanced the event schemas to support filtering by highlighted events.
- Added corresponding tests to ensure the correct generation of filter conditions for highlighted and active events.