### PR TITLE
feat: add dimension prop to ImageInput component and update usage in SubmitPage

### DIFF
--- a/src/components/Form/ImageInput.tsx
+++ b/src/components/Form/ImageInput.tsx
@@ -16,6 +16,7 @@ export type ImageInputProps = Omit<
   message?: React.ReactNode
   error?: boolean
   loading?: boolean
+  dimension?: "square" | "wide" | "vertical" | "circle" | "standard"
 }
 
 export default function ImageInput({
@@ -25,6 +26,7 @@ export default function ImageInput({
   label,
   message,
   className,
+  dimension = "wide",
   ...props
 }: ImageInputProps) {
   const hasDocument = typeof document !== "undefined"
@@ -76,7 +78,7 @@ export default function ImageInput({
     >
       <div className="image-input__label">{label}</div>
       <div className="image-input__value">
-        <ImgFixed dimension="wide" src={value} />
+        <ImgFixed dimension={dimension} src={value} />
         <div className="image-input__background" />
         {loading && <Loader size="medium" active />}
         {!loading && (

--- a/src/pages/submit/index.tsx
+++ b/src/pages/submit/index.tsx
@@ -631,6 +631,7 @@ export default function SubmitPage() {
                     onFileChange={uploadVerticalPoster}
                     loading={uploadingVerticalPoster}
                     error={verticalCoverError}
+                    dimension="vertical"
                     message={
                       (state.errorVerticalImageSize && (
                         <>


### PR DESCRIPTION
- Added a new `dimension` prop to the `ImageInput` component to allow for customizable image dimensions.
- Updated the default value of `dimension` to "wide" in the `ImageInput` component.
- Modified the `SubmitPage` to utilize the new `dimension` prop for vertical image uploads.