### PR TITLE
fix: bound recurrent event expansion and tighten recurrence validation

### DIFF
--- a/scripts/test-update-event-auth.ts
+++ b/scripts/test-update-event-auth.ts
@@ -1,0 +1,133 @@
+/**
+ * Local test script to verify the IDOR fix on the updateEvent endpoint.
+ *
+ * Usage:
+ *   npx ts-node scripts/test-update-event-auth.ts <event_id> <new_title> [port]
+ *
+ * Example:
+ *   npx ts-node scripts/test-update-event-auth.ts 550e8400-e29b-41d4-a716-446655440000 "Hacked Title"
+ *   npx ts-node scripts/test-update-event-auth.ts 550e8400-e29b-41d4-a716-446655440000 "Hacked Title" 4000
+ *
+ * The script creates a random wallet (which will never be the event owner),
+ * signs a PATCH request, and sends it to localhost. If the fix is in place,
+ * the server should respond with 403 Forbidden.
+ */
+import { Authenticator } from "@dcl/crypto"
+import { Wallet } from "ethers"
+import fetch from "node-fetch"
+
+import { signedHeaderFactory } from "decentraland-crypto-fetch"
+
+async function createRandomIdentity() {
+  const wallet = Wallet.createRandom()
+  const ephemeralWallet = Wallet.createRandom()
+
+  const ephemeralIdentity = {
+    privateKey: ephemeralWallet.privateKey,
+    publicKey: ephemeralWallet.publicKey,
+    address: ephemeralWallet.address,
+  }
+
+  const identity = await Authenticator.initializeAuthChain(
+    wallet.address,
+    ephemeralIdentity,
+    60, // 60 minutes expiry
+    (message: string) => wallet.signMessage(message)
+  )
+
+  console.log(`Wallet address: ${wallet.address}`)
+  return identity
+}
+
+async function main() {
+  const [eventId, newTitle, _portArg] = process.argv.slice(2)
+
+  if (!eventId || !newTitle) {
+    console.error(
+      "Usage: npx ts-node scripts/test-update-event-auth.ts <event_id> <new_title> [port]"
+    )
+    process.exit(1)
+  }
+
+  // const port = portArg || "4000"
+  const baseUrl = `https://events.decentraland.zone`
+  const path = `/api/events/${eventId}`
+  const url = `${baseUrl}${path}`
+
+  console.log(`Target: PATCH ${url}`)
+  console.log(`New title: "${newTitle}"`)
+  console.log()
+
+  // Create a random identity (guaranteed non-owner)
+  console.log("Creating random wallet identity...")
+  const identity = await createRandomIdentity()
+  console.log()
+
+  // Build signed headers
+  const createHeaders = signedHeaderFactory()
+  const headers = createHeaders(identity, "PATCH", path, {})
+
+  // Convert Headers to plain object for node-fetch
+  const headerObj: Record<string, string> = {}
+  headers.forEach((value: string, key: string) => {
+    headerObj[key] = value
+  })
+  headerObj["Content-Type"] = "application/json"
+
+  const body = JSON.stringify({ name: newTitle })
+
+  console.log(`Sending PATCH request as non-owner...`)
+  console.log()
+
+  try {
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: headerObj,
+      body,
+    })
+
+    const responseBody = await response.text()
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(responseBody)
+    } catch {
+      parsed = responseBody
+    }
+
+    console.log(`Status: ${response.status} ${response.statusText}`)
+    console.log(`Response:`, JSON.stringify(parsed, null, 2))
+    console.log()
+
+    if (response.status === 403) {
+      console.log(
+        "PASS: Server correctly rejected the non-owner update (403 Forbidden)"
+      )
+      process.exit(0)
+    } else if (response.status === 200) {
+      console.log("FAIL: Server allowed a non-owner to update the event!")
+      console.log("The IDOR vulnerability is still present.")
+      process.exit(1)
+    } else {
+      console.log(
+        `INCONCLUSIVE: Unexpected status ${response.status}. ` +
+          "Check that the server is running and the event ID exists."
+      )
+      process.exit(2)
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ECONNREFUSED"
+    ) {
+      console.error(
+        `ERROR: Could not connect to ${baseUrl}. Is the server running?`
+      )
+    } else {
+      console.error("ERROR:", error)
+    }
+    process.exit(2)
+  }
+}
+
+main()

--- a/src/entities/Event/cron.test.ts
+++ b/src/entities/Event/cron.test.ts
@@ -1,0 +1,98 @@
+import JobContext from "decentraland-gatsby/dist/entities/Job/context"
+
+import { updateNextStartAt } from "./cron"
+import EventModel from "./model"
+import { Frequency } from "./types"
+
+jest.mock("./model")
+
+function makeEvent(overrides: Record<string, unknown> = {}) {
+  const startAt = new Date()
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    start_at: startAt,
+    finish_at: new Date(startAt.getTime() + 60 * 60 * 1000),
+    duration: 60 * 60 * 1000,
+    recurrent: true,
+    recurrent_interval: 1,
+    recurrent_frequency: Frequency.DAILY,
+    recurrent_count: null,
+    recurrent_until: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    recurrent_weekday_mask: 0,
+    recurrent_month_mask: 0,
+    recurrent_setpos: null,
+    recurrent_monthday: null,
+    recurrent_dates: [startAt],
+    next_start_at: startAt,
+    next_finish_at: new Date(startAt.getTime() + 60 * 60 * 1000),
+    ...overrides,
+  }
+}
+
+function makeCtx(): JobContext<{}> {
+  return { log: jest.fn() } as unknown as JobContext<{}>
+}
+
+describe("updateNextStartAt", () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("when the event's recurrence would exceed the past-iteration cap", () => {
+    // HOURLY + start_at 10 years ago = ~88k iterations, over the 50k cap.
+    const tenYearsAgo = new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000)
+
+    it("should skip the event without calling EventModel.update", async () => {
+      const pathological = makeEvent({
+        start_at: tenYearsAgo,
+        recurrent_frequency: Frequency.HOURLY,
+      })
+      ;(EventModel.getRecurrentFinishedEvents as jest.Mock).mockResolvedValue([
+        pathological,
+      ])
+
+      await updateNextStartAt(makeCtx())
+
+      expect(EventModel.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when the event's recurrence is within the cap", () => {
+    it("should update the event", async () => {
+      const event = makeEvent()
+      ;(EventModel.getRecurrentFinishedEvents as jest.Mock).mockResolvedValue([
+        event,
+      ])
+
+      await updateNextStartAt(makeCtx())
+
+      expect(EventModel.update).toHaveBeenCalled()
+    })
+  })
+
+  describe("when there is a mix of pathological and healthy events", () => {
+    it("should skip only the pathological one and still update the healthy one", async () => {
+      const tenYearsAgo = new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000)
+      const pathological = makeEvent({
+        id: "00000000-0000-0000-0000-000000000bad",
+        start_at: tenYearsAgo,
+        recurrent_frequency: Frequency.HOURLY,
+      })
+      const healthy = makeEvent({
+        id: "00000000-0000-0000-0000-0000000000ad",
+      })
+      ;(EventModel.getRecurrentFinishedEvents as jest.Mock).mockResolvedValue([
+        pathological,
+        healthy,
+      ])
+
+      await updateNextStartAt(makeCtx())
+
+      expect(EventModel.update).toHaveBeenCalledTimes(1)
+      expect(EventModel.update).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ id: healthy.id })
+      )
+    })
+  })
+})

--- a/src/entities/Event/cron.ts
+++ b/src/entities/Event/cron.ts
@@ -3,10 +3,11 @@ import { NotificationType } from "@dcl/schemas"
 import JobContext from "decentraland-gatsby/dist/entities/Job/context"
 
 import EventModel from "./model"
-import { EventAttributes } from "./types"
+import { EventAttributes, MAX_RECURRENT_PAST_ITERATIONS } from "./types"
 import {
   calculateNextRecurrentDates,
   calculateRecurrentProperties,
+  estimateRecurrentPastIterations,
 } from "./utils"
 import Communities from "../../api/Communities"
 import EventAttendeeModel from "../EventAttendee/model"
@@ -23,6 +24,20 @@ export async function updateNextStartAt(ctx: JobContext<{}>) {
   const events = await EventModel.getRecurrentFinishedEvents()
 
   for (const event of events) {
+    // Route handlers reject rules whose past expansion exceeds the cap
+    // at request time. This guard catches any legacy or hand-inserted
+    // row that would otherwise make the cron burn excessive CPU walking
+    // from dtstart to now. Skip the row without mutating its state so
+    // the event keeps its last-known-good recurrent_dates.
+    if (
+      estimateRecurrentPastIterations(event) > MAX_RECURRENT_PAST_ITERATIONS
+    ) {
+      ctx.log(
+        `skipping updateNextStartAt for event "${event.id}": recurrence rule exceeds the iteration cap`
+      )
+      continue
+    }
+
     const update = {
       ...calculateRecurrentProperties(event),
       ...calculateNextRecurrentDates(event),

--- a/src/entities/Event/routes/createEvent.ts
+++ b/src/entities/Event/routes/createEvent.ts
@@ -23,9 +23,11 @@ import {
   DeprecatedEventAttributes,
   EventAttributes,
   MAX_EVENT_DURATION,
+  MAX_RECURRENT_PAST_ITERATIONS,
 } from "../types"
 import {
   calculateRecurrentProperties,
+  estimateRecurrentPastIterations,
   eventTargetUrl,
   validateImageUrl,
 } from "../utils"
@@ -95,6 +97,20 @@ export async function createEvent(req: WithAuthProfile<WithAuth>) {
   if (recurrent.duration > MAX_EVENT_DURATION) {
     throw new RequestError(
       `Maximum allowed duration ${MAX_EVENT_DURATION / Time.Hour}Hrs`,
+      RequestError.BadRequest,
+      { body: data }
+    )
+  }
+
+  // Reject rules whose expansion from `start_at` to `now` would burn
+  // excessive CPU inside rrule. The schema already bounds frequency,
+  // interval, and count; this catches combinations that slip through
+  // (e.g. HOURLY with a very old `start_at`). See MAX_RECURRENT_PAST_ITERATIONS.
+  if (
+    estimateRecurrentPastIterations(recurrent) > MAX_RECURRENT_PAST_ITERATIONS
+  ) {
+    throw new RequestError(
+      `Recurrence rule expands to too many past occurrences from the start date; choose a later start date or a coarser frequency`,
       RequestError.BadRequest,
       { body: data }
     )

--- a/src/entities/Event/routes/createEvent.ts
+++ b/src/entities/Event/routes/createEvent.ts
@@ -92,25 +92,33 @@ export async function createEvent(req: WithAuthProfile<WithAuth>) {
     )
   }
 
-  const recurrent = calculateRecurrentProperties(data)
-
-  if (recurrent.duration > MAX_EVENT_DURATION) {
+  // Reject rules whose expansion from `start_at` to `now` would burn
+  // excessive CPU inside rrule. The schema already bounds frequency,
+  // interval, and count; this catches combinations that slip through
+  // (e.g. HOURLY with a very old `start_at`). Runs before
+  // calculateRecurrentProperties so we don't pay the rrule.between()
+  // cost for a request we're about to reject.
+  if (
+    estimateRecurrentPastIterations({
+      ...data,
+      start_at: Time.date(data.start_at)!,
+      recurrent_until: data.recurrent_until
+        ? Time.date(data.recurrent_until)
+        : null,
+    }) > MAX_RECURRENT_PAST_ITERATIONS
+  ) {
     throw new RequestError(
-      `Maximum allowed duration ${MAX_EVENT_DURATION / Time.Hour}Hrs`,
+      `Recurrence rule expands to too many past occurrences from the start date; choose a later start date or a coarser frequency`,
       RequestError.BadRequest,
       { body: data }
     )
   }
 
-  // Reject rules whose expansion from `start_at` to `now` would burn
-  // excessive CPU inside rrule. The schema already bounds frequency,
-  // interval, and count; this catches combinations that slip through
-  // (e.g. HOURLY with a very old `start_at`). See MAX_RECURRENT_PAST_ITERATIONS.
-  if (
-    estimateRecurrentPastIterations(recurrent) > MAX_RECURRENT_PAST_ITERATIONS
-  ) {
+  const recurrent = calculateRecurrentProperties(data)
+
+  if (recurrent.duration > MAX_EVENT_DURATION) {
     throw new RequestError(
-      `Recurrence rule expands to too many past occurrences from the start date; choose a later start date or a coarser frequency`,
+      `Maximum allowed duration ${MAX_EVENT_DURATION / Time.Hour}Hrs`,
       RequestError.BadRequest,
       { body: data }
     )

--- a/src/entities/Event/routes/updateEvent.test.ts
+++ b/src/entities/Event/routes/updateEvent.test.ts
@@ -545,7 +545,8 @@ describe("updateEvent", () => {
         event = createBaseEvent({
           start_at: tenYearsAgo,
           recurrent: true,
-          recurrent_frequency: "HOURLY" as EventAttributes["recurrent_frequency"],
+          recurrent_frequency:
+            "HOURLY" as EventAttributes["recurrent_frequency"],
           recurrent_interval: 1,
           recurrent_until: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
         })
@@ -579,7 +580,8 @@ describe("updateEvent", () => {
         event = createBaseEvent({
           start_at: tenYearsAgo,
           recurrent: true,
-          recurrent_frequency: "HOURLY" as EventAttributes["recurrent_frequency"],
+          recurrent_frequency:
+            "HOURLY" as EventAttributes["recurrent_frequency"],
           recurrent_interval: 1,
           recurrent_until: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
         })
@@ -609,7 +611,8 @@ describe("updateEvent", () => {
         event = createBaseEvent({
           start_at: tenYearsAgo,
           recurrent: true,
-          recurrent_frequency: "DAILY" as EventAttributes["recurrent_frequency"],
+          recurrent_frequency:
+            "DAILY" as EventAttributes["recurrent_frequency"],
           recurrent_interval: 1,
           recurrent_until: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
         })

--- a/src/entities/Event/routes/updateEvent.test.ts
+++ b/src/entities/Event/routes/updateEvent.test.ts
@@ -57,14 +57,18 @@ jest.mock("../schemas", () => ({
     additionalProperties: true,
   },
 }))
-jest.mock("../utils", () => ({
-  calculateRecurrentProperties: () => ({
-    recurrent_dates: [new Date("2030-01-01T00:00:00Z")],
-    finish_at: new Date("2030-01-01T01:00:00Z"),
-  }),
-  eventTargetUrl: () => "https://decentraland.org/jump",
-  validateImageUrl: () => Promise.resolve(undefined),
-}))
+jest.mock("../utils", () => {
+  const actual = jest.requireActual("../utils")
+  return {
+    ...actual,
+    calculateRecurrentProperties: () => ({
+      recurrent_dates: [new Date("2030-01-01T00:00:00Z")],
+      finish_at: new Date("2030-01-01T01:00:00Z"),
+    }),
+    eventTargetUrl: () => "https://decentraland.org/jump",
+    validateImageUrl: () => Promise.resolve(undefined),
+  }
+})
 jest.mock("../../../api/Communities", () => ({
   __esModule: true,
   default: {
@@ -522,6 +526,114 @@ describe("updateEvent", () => {
         )
 
         expect(EventModel.update).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe("when the owner edits a grandfathered recurrent event", () => {
+    // An event that would exceed MAX_RECURRENT_PAST_ITERATIONS if it were
+    // being created today: HOURLY frequency with start_at 10 years ago
+    // (~88k past iterations, over the 50k cap).
+    const tenYearsAgo = new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000)
+
+    describe("and the edit touches only non-recurrence fields", () => {
+      let event: DeprecatedEventAttributes
+      let profile: ProfileSettingsSessionAttributes
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        event = createBaseEvent({
+          start_at: tenYearsAgo,
+          recurrent: true,
+          recurrent_frequency: "HOURLY" as EventAttributes["recurrent_frequency"],
+          recurrent_interval: 1,
+          recurrent_until: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+        })
+        profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, { name: "Updated name" })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        ;(EventAttendeeModel.findOne as jest.Mock).mockResolvedValueOnce(null)
+        ;(EventModel.selectNextStartAt as jest.Mock).mockReturnValueOnce(
+          new Date("2030-01-01T00:00:00Z")
+        )
+        ;(EventModel.toPublic as jest.Mock).mockReturnValueOnce({
+          ...event,
+          attending: false,
+        })
+      })
+
+      it("should not reject the edit for exceeding the iteration cap", async () => {
+        await expect(updateEvent(req)).resolves.toBeDefined()
+        expect(EventModel.update).toHaveBeenCalled()
+      })
+    })
+
+    describe("and the edit touches start_at", () => {
+      let event: DeprecatedEventAttributes
+      let profile: ProfileSettingsSessionAttributes
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        event = createBaseEvent({
+          start_at: tenYearsAgo,
+          recurrent: true,
+          recurrent_frequency: "HOURLY" as EventAttributes["recurrent_frequency"],
+          recurrent_interval: 1,
+          recurrent_until: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+        })
+        profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, {
+          start_at: tenYearsAgo.toJSON(),
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+      })
+
+      it("should reject the edit for exceeding the iteration cap", async () => {
+        await expect(updateEvent(req)).rejects.toThrow(
+          /too many past occurrences/
+        )
+        expect(EventModel.update).not.toHaveBeenCalled()
+      })
+    })
+
+    describe("and the edit changes the recurrence frequency", () => {
+      let event: DeprecatedEventAttributes
+      let profile: ProfileSettingsSessionAttributes
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        event = createBaseEvent({
+          start_at: tenYearsAgo,
+          recurrent: true,
+          recurrent_frequency: "DAILY" as EventAttributes["recurrent_frequency"],
+          recurrent_interval: 1,
+          recurrent_until: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+        })
+        profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, { recurrent_frequency: "HOURLY" })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+      })
+
+      it("should reject the edit for exceeding the iteration cap", async () => {
+        await expect(updateEvent(req)).rejects.toThrow(
+          /too many past occurrences/
+        )
+        expect(EventModel.update).not.toHaveBeenCalled()
+      })
+
+      it("should fail fast without calling Catalyst.getProfiles", async () => {
+        mockGetProfiles.mockClear()
+        await expect(updateEvent(req)).rejects.toThrow()
+
+        // The cap check is placed above the external-API block so a
+        // rejected PATCH doesn't cost an upstream profile lookup.
+        expect(mockGetProfiles).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -38,6 +38,8 @@ import {
   DeprecatedEventAttributes,
   EventAttributes,
   MAX_EVENT_DURATION,
+  MAX_RECURRENT_PAST_ITERATIONS,
+  RECURRENCE_REQUEST_FIELDS,
   approveEventAttributes,
   editAnyEventAttributes,
   editEventAttributes,
@@ -45,6 +47,7 @@ import {
 } from "../types"
 import {
   calculateRecurrentProperties,
+  estimateRecurrentPastIterations,
   eventTargetUrl,
   validateImageUrl,
 } from "../utils"
@@ -150,6 +153,29 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
     start_at: Time.date(updatedAttributes.start_at)?.toJSON(),
     recurrent_until: Time.date(updatedAttributes.recurrent_until)?.toJSON(),
   })
+
+  // Enforce the past-iteration cap only when this request actually
+  // touches a recurrence-related field. A routine edit to name,
+  // description, image, etc. of a grandfathered row whose start_at has
+  // aged past the cap should not start failing as time moves forward.
+  // Placed immediately after validateUpdateEvent so a rejected request
+  // fails fast, before any downstream external API calls (Catalyst,
+  // Land, Places, Communities).
+  const touchesRecurrence = RECURRENCE_REQUEST_FIELDS.some(
+    (field) => req.body[field] !== undefined
+  )
+  if (
+    touchesRecurrence &&
+    updatedAttributes.recurrent &&
+    estimateRecurrentPastIterations(updatedAttributes) >
+      MAX_RECURRENT_PAST_ITERATIONS
+  ) {
+    throw new RequestError(
+      `Recurrence rule expands to too many past occurrences from the start date; choose a later start date or a coarser frequency`,
+      RequestError.BadRequest,
+      { body: updatedAttributes }
+    )
+  }
 
   if (req.body.image && req.body.image !== event.image) {
     await validateImageUrl(req.body.image)

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -39,7 +39,6 @@ import {
   EventAttributes,
   MAX_EVENT_DURATION,
   MAX_RECURRENT_PAST_ITERATIONS,
-  RECURRENCE_REQUEST_FIELDS,
   approveEventAttributes,
   editAnyEventAttributes,
   editEventAttributes,
@@ -161,9 +160,17 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
   // Placed immediately after validateUpdateEvent so a rejected request
   // fails fast, before any downstream external API calls (Catalyst,
   // Land, Places, Communities).
-  const touchesRecurrence = RECURRENCE_REQUEST_FIELDS.some(
-    (field) => req.body[field] !== undefined
-  )
+  // weekday/month masks, monthday, and setpos are filters that don't
+  // change rrule's iteration count — only which dates it emits — so
+  // they're intentionally excluded.
+  const touchesRecurrence = [
+    "start_at",
+    "recurrent",
+    "recurrent_frequency",
+    "recurrent_interval",
+    "recurrent_count",
+    "recurrent_until",
+  ].some((field) => req.body[field] !== undefined)
   if (
     touchesRecurrence &&
     updatedAttributes.recurrent &&

--- a/src/entities/Event/schemas.test.ts
+++ b/src/entities/Event/schemas.test.ts
@@ -1,13 +1,31 @@
 import RequestError from "decentraland-gatsby/dist/entities/Route/error"
 import { createValidator } from "decentraland-gatsby/dist/entities/Route/validate"
 
-import { getEventListByPlacesBodySchema, getEventListQuery } from "./schemas"
+import {
+  getEventListByPlacesBodySchema,
+  getEventListQuery,
+  newEventSchema,
+} from "./schemas"
 import { EventListParams } from "./types"
 
 const validateQuery = createValidator<EventListParams>(getEventListQuery)
 
 type PlacesBody = { placeIds?: string[]; communityId?: string }
 const validateBody = createValidator<PlacesBody>(getEventListByPlacesBodySchema)
+
+const validateNewEvent = createValidator<Record<string, unknown>>(
+  newEventSchema as any
+)
+
+function validNewEventBase() {
+  return {
+    name: "Test Event",
+    start_at: new Date("2030-01-01T00:00:00Z").toJSON(),
+    duration: 60 * 60 * 1000,
+    x: 0,
+    y: 0,
+  }
+}
 
 describe("getEventListQuery schema", () => {
   afterEach(() => {
@@ -149,6 +167,125 @@ describe("getEventListByPlacesBodySchema", () => {
 
     it("should throw a RequestError", () => {
       expect(() => validateBody(body)).toThrow(RequestError)
+    })
+  })
+})
+
+describe("newEventSchema", () => {
+  describe("when recurrent_frequency is one of the allowed values", () => {
+    it.each(["HOURLY", "DAILY", "WEEKLY", "MONTHLY", "YEARLY"])(
+      "should accept %s",
+      (freq) => {
+        const body = {
+          ...validNewEventBase(),
+          recurrent: true,
+          recurrent_frequency: freq,
+          recurrent_count: 5,
+        }
+        expect(() => validateNewEvent(body)).not.toThrow()
+      }
+    )
+  })
+
+  describe("when recurrent_frequency is MINUTELY", () => {
+    it("should throw a RequestError", () => {
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "MINUTELY",
+        recurrent_count: 5,
+      }
+      expect(() => validateNewEvent(body)).toThrow(RequestError)
+    })
+  })
+
+  describe("when recurrent_frequency is SECONDLY", () => {
+    it("should throw a RequestError", () => {
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "SECONDLY",
+        recurrent_count: 5,
+      }
+      expect(() => validateNewEvent(body)).toThrow(RequestError)
+    })
+  })
+
+  describe("when recurrent_interval exceeds the maximum", () => {
+    it("should throw a RequestError", () => {
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "DAILY",
+        recurrent_interval: 1001,
+        recurrent_count: 5,
+      }
+      expect(() => validateNewEvent(body)).toThrow(RequestError)
+    })
+  })
+
+  describe("when recurrent_count exceeds the maximum", () => {
+    it("should throw a RequestError", () => {
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "DAILY",
+        recurrent_count: 1001,
+      }
+      expect(() => validateNewEvent(body)).toThrow(RequestError)
+    })
+  })
+
+  describe("when recurrent_interval is at the boundary (1000)", () => {
+    it("should accept the input", () => {
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "DAILY",
+        recurrent_interval: 1000,
+        recurrent_count: 5,
+      }
+      expect(() => validateNewEvent(body)).not.toThrow()
+    })
+  })
+
+  describe("when recurrent_count is at the boundary (1000)", () => {
+    it("should accept the input", () => {
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "DAILY",
+        recurrent_count: 1000,
+      }
+      expect(() => validateNewEvent(body)).not.toThrow()
+    })
+  })
+
+  describe("when recurrent_count is fractional", () => {
+    it("should throw a RequestError", () => {
+      // A fractional count would never hit rrule's integer count check
+      // (count decrements from 0.5 to -0.5 to ...), letting iteration
+      // run until MAXYEAR. Must be rejected.
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "DAILY",
+        recurrent_count: 0.5,
+      }
+      expect(() => validateNewEvent(body)).toThrow(RequestError)
+    })
+  })
+
+  describe("when recurrent_interval is fractional", () => {
+    it("should throw a RequestError", () => {
+      const body = {
+        ...validNewEventBase(),
+        recurrent: true,
+        recurrent_frequency: "DAILY",
+        recurrent_interval: 1.5,
+        recurrent_count: 5,
+      }
+      expect(() => validateNewEvent(body)).toThrow(RequestError)
     })
   })
 })

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -535,7 +535,7 @@ export const newEventSchema = {
     },
     recurrent_interval: {
       type: "integer",
-      minimum: 0,
+      minimum: 1,
       maximum: 1000,
     },
     recurrent_count: {

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -6,7 +6,7 @@ import {
   apiResultSchema,
 } from "decentraland-gatsby/dist/entities/Schema/types"
 
-import { Frequencies } from "./types"
+import { AllowedInputFrequencies, Frequencies } from "./types"
 
 export const getEventParamsSchema: AjvObjectSchema = {
   type: "object",
@@ -516,29 +516,32 @@ export const newEventSchema = {
       type: "boolean",
     },
     recurrent_frequency: {
-      enum: [...Frequencies, null],
+      enum: [...AllowedInputFrequencies, null],
     },
     recurrent_setpos: {
-      type: ["number", "null"],
+      type: ["integer", "null"],
       minimum: -1,
     },
     recurrent_monthday: {
-      type: ["number", "null"],
+      type: ["integer", "null"],
     },
     recurrent_weekday_mask: {
-      type: "number",
+      type: "integer",
       minimum: 0,
     },
     recurrent_month_mask: {
-      type: "number",
+      type: "integer",
       minimum: 0,
     },
     recurrent_interval: {
-      type: "number",
+      type: "integer",
       minimum: 0,
+      maximum: 1000,
     },
     recurrent_count: {
-      type: ["number", "null"],
+      type: ["integer", "null"],
+      minimum: 0,
+      maximum: 1000,
     },
     recurrent_until: {
       type: ["string", "null"],

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -118,19 +118,6 @@ export const FREQUENCY_PERIOD_MS: Record<Frequency, number> = {
   [Frequency.YEARLY]: 365 * 24 * 60 * 60 * 1_000,
 }
 
-// Request body fields that, if touched by a PATCH, require re-running
-// the past-iteration cap check. weekday/month masks, monthday, and
-// setpos are filters that don't change rrule's iteration count — only
-// which dates it emits — so they're intentionally excluded.
-export const RECURRENCE_REQUEST_FIELDS = [
-  "start_at",
-  "recurrent",
-  "recurrent_frequency",
-  "recurrent_interval",
-  "recurrent_count",
-  "recurrent_until",
-] as const
-
 export type EventAttributes = {
   id: string // primary key
   name: string

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -21,6 +21,17 @@ export const Frequencies = [
   Frequency.SECONDLY,
 ]
 
+// Frequencies that an API client is allowed to submit on create/update.
+// Sub-hourly frequencies are rejected because they have no product use
+// case and expand to enormous iteration counts in rrule.
+export const AllowedInputFrequencies = [
+  Frequency.YEARLY,
+  Frequency.MONTHLY,
+  Frequency.WEEKLY,
+  Frequency.DAILY,
+  Frequency.HOURLY,
+]
+
 export enum WeekdayMask {
   NONE = 0,
   SUNDAY = 1 << 0,
@@ -85,6 +96,40 @@ export enum Position {
 }
 
 export const MAX_EVENT_RECURRENT = 10
+
+// Upper bound on how many past occurrences rrule is asked to step through
+// when expanding a recurrence. Past iterations happen inside rrule's inner
+// loop (even with .between) and are bounded by (now - start_at) / period.
+// 50k ≈ ~50 ms of rrule work on commodity CPUs — enough headroom for
+// legitimate DAILY/WEEKLY events going back many years, tight enough to
+// reject pathological HOURLY rules anchored in the distant past.
+export const MAX_RECURRENT_PAST_ITERATIONS = 50_000
+
+// Approximate period, in milliseconds, of one rrule step at each
+// frequency. MONTHLY and YEARLY are nominal (30 / 365 days); the check
+// is a coarse upper bound, not a billing estimate.
+export const FREQUENCY_PERIOD_MS: Record<Frequency, number> = {
+  [Frequency.SECONDLY]: 1_000,
+  [Frequency.MINUTELY]: 60 * 1_000,
+  [Frequency.HOURLY]: 60 * 60 * 1_000,
+  [Frequency.DAILY]: 24 * 60 * 60 * 1_000,
+  [Frequency.WEEKLY]: 7 * 24 * 60 * 60 * 1_000,
+  [Frequency.MONTHLY]: 30 * 24 * 60 * 60 * 1_000,
+  [Frequency.YEARLY]: 365 * 24 * 60 * 60 * 1_000,
+}
+
+// Request body fields that, if touched by a PATCH, require re-running
+// the past-iteration cap check. weekday/month masks, monthday, and
+// setpos are filters that don't change rrule's iteration count — only
+// which dates it emits — so they're intentionally excluded.
+export const RECURRENCE_REQUEST_FIELDS = [
+  "start_at",
+  "recurrent",
+  "recurrent_frequency",
+  "recurrent_interval",
+  "recurrent_count",
+  "recurrent_until",
+] as const
 
 export type EventAttributes = {
   id: string // primary key

--- a/src/entities/Event/utils.test.ts
+++ b/src/entities/Event/utils.test.ts
@@ -72,9 +72,7 @@ describe("futureRecurrentDates", () => {
         ...baseRecurrence,
         start_at: oneMonthAgo,
         recurrent_frequency: Frequency.MONTHLY,
-        recurrent_until: new Date(
-          Date.now() + 2 * 365 * 24 * 60 * 60 * 1000
-        ),
+        recurrent_until: new Date(Date.now() + 2 * 365 * 24 * 60 * 60 * 1000),
       })
       expect(dates.length).toBeGreaterThan(1)
     })
@@ -203,9 +201,7 @@ describe("estimateRecurrentPastIterations", () => {
       // over-estimate to ~53k and trip the cap; the accurate count
       // is ~26k.
       const sixYearsAgo = new Date(Date.now() - 6 * 365 * 24 * 60 * 60 * 1000)
-      const threeYearsAgo = new Date(
-        Date.now() - 3 * 365 * 24 * 60 * 60 * 1000
-      )
+      const threeYearsAgo = new Date(Date.now() - 3 * 365 * 24 * 60 * 60 * 1000)
       const result = estimateRecurrentPastIterations({
         ...baseOptions,
         start_at: sixYearsAgo,

--- a/src/entities/Event/utils.test.ts
+++ b/src/entities/Event/utils.test.ts
@@ -1,4 +1,10 @@
-import { fromEventTime, toEventTime } from "./utils"
+import { Frequency, MAX_EVENT_RECURRENT } from "./types"
+import {
+  estimateRecurrentPastIterations,
+  fromEventTime,
+  futureRecurrentDates,
+  toEventTime,
+} from "./utils"
 
 test(`fromEventTime`, () => {
   expect(fromEventTime()).toEqual([0, 60 * 24])
@@ -16,4 +22,295 @@ test(`toEventTime`, () => {
   expect(toEventTime(0, 48 * 60)).toEqual(["0000", "2400"])
   expect(toEventTime(30, 23 * 60 + 30)).toEqual(["0030", "2330"])
   expect(toEventTime(12 * 60, 0)).toEqual(["1200", "1200"])
+})
+
+describe("futureRecurrentDates", () => {
+  const baseRecurrence = {
+    duration: 60 * 60 * 1000,
+    recurrent: true,
+    recurrent_interval: 1,
+    recurrent_setpos: null,
+    recurrent_monthday: null,
+    recurrent_weekday_mask: 0,
+    recurrent_month_mask: 0,
+    recurrent_count: null,
+    recurrent_until: null,
+  }
+
+  describe("when the event is not recurrent", () => {
+    it("should return an empty array", () => {
+      const dates = futureRecurrentDates({
+        ...baseRecurrence,
+        recurrent: false,
+        recurrent_frequency: null,
+        start_at: new Date(),
+      })
+      expect(dates).toEqual([])
+    })
+  })
+
+  describe("when recurrent_until is already in the past", () => {
+    it("should return an empty array", () => {
+      const dates = futureRecurrentDates({
+        ...baseRecurrence,
+        start_at: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.DAILY,
+        recurrent_until: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      })
+      expect(dates).toEqual([])
+    })
+  })
+
+  describe("when the recurrence is MONTHLY with no monthday mask set", () => {
+    it("should infer bymonthday from start_at and produce MAX_EVENT_RECURRENT future dates", () => {
+      // start_at one month ago — by moving the day-of-month to a value
+      // that wouldn't be inferred from `now`, we exercise rrule's default
+      // inference from dtstart. Without the byweekday:[]/bymonth:[] fix,
+      // MONTHLY would also yield empty results.
+      const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      const dates = futureRecurrentDates({
+        ...baseRecurrence,
+        start_at: oneMonthAgo,
+        recurrent_frequency: Frequency.MONTHLY,
+        recurrent_until: new Date(
+          Date.now() + 2 * 365 * 24 * 60 * 60 * 1000
+        ),
+      })
+      expect(dates.length).toBeGreaterThan(1)
+    })
+  })
+
+  describe("when the recurrence is WEEKLY with no weekday mask set", () => {
+    it("should infer the weekday from start_at and produce MAX_EVENT_RECURRENT future dates", () => {
+      // start_at one year ago on a known weekday (Thursday for most years)
+      const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
+      const options = {
+        start_at: oneYearAgo,
+        duration: 60 * 60 * 1000,
+        recurrent: true,
+        recurrent_interval: 1,
+        recurrent_frequency: Frequency.WEEKLY,
+        recurrent_setpos: null,
+        recurrent_monthday: null,
+        recurrent_weekday_mask: 0,
+        recurrent_month_mask: 0,
+        recurrent_count: null,
+        recurrent_until: new Date(Date.now() + 5 * 365 * 24 * 60 * 60 * 1000),
+      }
+
+      const dates = futureRecurrentDates(options)
+
+      // Without the fix, rrule receives `byweekday: []` and returns zero
+      // dates, producing the `[start_at]` fallback (length 1).
+      expect(dates.length).toBeGreaterThan(1)
+    })
+  })
+
+  describe("when start_at is years in the past with an absurdly large recurrent_count", () => {
+    it("should not allocate past dates and should return MAX_EVENT_RECURRENT future dates", () => {
+      const options = {
+        start_at: new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000),
+        duration: 60 * 60 * 1000,
+        recurrent: true,
+        recurrent_interval: 1,
+        recurrent_frequency: Frequency.HOURLY,
+        recurrent_setpos: null,
+        recurrent_monthday: null,
+        recurrent_weekday_mask: 0,
+        recurrent_month_mask: 0,
+        recurrent_count: 2_000_000_000,
+        recurrent_until: null,
+      }
+
+      const started = Date.now()
+      const dates = futureRecurrentDates(options)
+      const elapsed = Date.now() - started
+
+      // Before the between() refactor, rrule.all(iterator) pushed every
+      // past hour into the result array (~17k Date objects for 2 years)
+      // before the filter stripped them. Scaling start_at further back
+      // crashed the process. Now past occurrences are iterated internally
+      // by rrule but never allocated, and our iterator only runs on
+      // future dates. The timing bound is generous because jest workers
+      // run in parallel under load; we only care that the call doesn't
+      // hang or OOM.
+      expect(elapsed).toBeLessThan(5000)
+      expect(dates.length).toBe(MAX_EVENT_RECURRENT)
+      for (const date of dates) {
+        expect(date.getTime()).toBeGreaterThanOrEqual(started)
+      }
+    })
+  })
+})
+
+describe("estimateRecurrentPastIterations", () => {
+  // Default to a future recurrent_until so the estimator's terminator
+  // gate (mirrors toRRule — rules without count or until are treated
+  // as non-recurring and return 0) doesn't short-circuit tests that
+  // are exercising the span math.
+  const farFutureUntil = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000)
+  const baseOptions = {
+    start_at: new Date(),
+    recurrent: true,
+    recurrent_interval: 1,
+    recurrent_frequency: Frequency.DAILY,
+    recurrent_setpos: null,
+    recurrent_monthday: null,
+    recurrent_weekday_mask: 0,
+    recurrent_month_mask: 0,
+    recurrent_count: null,
+    recurrent_until: farFutureUntil,
+  }
+
+  describe("when the event is not recurrent", () => {
+    it("should return 0", () => {
+      expect(
+        estimateRecurrentPastIterations({ ...baseOptions, recurrent: false })
+      ).toBe(0)
+    })
+  })
+
+  describe("when start_at is in the future", () => {
+    it("should return 0", () => {
+      expect(
+        estimateRecurrentPastIterations({
+          ...baseOptions,
+          start_at: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          recurrent_frequency: Frequency.HOURLY,
+        })
+      ).toBe(0)
+    })
+  })
+
+  describe("when neither recurrent_count nor recurrent_until is set", () => {
+    it("should return 0 because the rule won't actually iterate", () => {
+      expect(
+        estimateRecurrentPastIterations({
+          ...baseOptions,
+          start_at: new Date(Date.now() - 5 * 365 * 24 * 60 * 60 * 1000),
+          recurrent_count: null,
+          recurrent_until: null,
+        })
+      ).toBe(0)
+    })
+  })
+
+  describe("when recurrent_until is already in the past", () => {
+    it("should bound the iteration estimate by (until - start_at), not (now - start_at)", () => {
+      // start_at 6 years ago, until 3 years ago. rrule will iterate
+      // from start_at to until, not from start_at to now. With the
+      // naive (now - start_at) span, an HOURLY rule here would
+      // over-estimate to ~53k and trip the cap; the accurate count
+      // is ~26k.
+      const sixYearsAgo = new Date(Date.now() - 6 * 365 * 24 * 60 * 60 * 1000)
+      const threeYearsAgo = new Date(
+        Date.now() - 3 * 365 * 24 * 60 * 60 * 1000
+      )
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: sixYearsAgo,
+        recurrent_frequency: Frequency.HOURLY,
+        recurrent_until: threeYearsAgo,
+      })
+      expect(result).toBeGreaterThan(25_000)
+      expect(result).toBeLessThan(28_000)
+    })
+  })
+
+  describe("when the rule is DAILY and start_at is 5 years in the past", () => {
+    it("should estimate roughly 5 years of days", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 5 * 365 * 24 * 60 * 60 * 1000),
+      })
+      expect(result).toBeGreaterThan(1800)
+      expect(result).toBeLessThan(1900)
+    })
+  })
+
+  describe("when the rule is HOURLY and start_at is 1 year in the past", () => {
+    it("should estimate roughly 8760 iterations", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.HOURLY,
+      })
+      expect(result).toBeGreaterThan(8700)
+      expect(result).toBeLessThan(8800)
+    })
+  })
+
+  describe("when recurrent_count is smaller than the span estimate", () => {
+    it("should be bounded by recurrent_count", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 100 * 365 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.HOURLY,
+        recurrent_count: 500,
+      })
+      expect(result).toBe(500)
+    })
+  })
+
+  describe("when recurrent_count is larger than the span estimate", () => {
+    it("should be bounded by the time span", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.DAILY,
+        recurrent_count: 1000,
+      })
+      expect(result).toBeGreaterThan(6.5)
+      expect(result).toBeLessThan(7.5)
+    })
+  })
+
+  describe("when the rule is WEEKLY and start_at is 2 years in the past", () => {
+    it("should estimate roughly 104 iterations", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.WEEKLY,
+      })
+      expect(result).toBeGreaterThan(100)
+      expect(result).toBeLessThan(110)
+    })
+  })
+
+  describe("when the rule is MONTHLY and start_at is 10 years in the past", () => {
+    it("should estimate roughly 120 iterations", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.MONTHLY,
+      })
+      expect(result).toBeGreaterThan(115)
+      expect(result).toBeLessThan(125)
+    })
+  })
+
+  describe("when the rule is YEARLY and start_at is 100 years in the past", () => {
+    it("should estimate roughly 100 iterations", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 100 * 365 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.YEARLY,
+      })
+      expect(result).toBeGreaterThan(99)
+      expect(result).toBeLessThan(101)
+    })
+  })
+
+  describe("when recurrent_interval is 0 (coerced to 1)", () => {
+    it("should treat interval as 1", () => {
+      const result = estimateRecurrentPastIterations({
+        ...baseOptions,
+        start_at: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+        recurrent_frequency: Frequency.DAILY,
+        recurrent_interval: 0,
+      })
+      expect(result).toBeGreaterThan(360)
+      expect(result).toBeLessThan(370)
+    })
+  })
 })

--- a/src/entities/Event/utils.ts
+++ b/src/entities/Event/utils.ts
@@ -9,6 +9,7 @@ import {
   EventAttributes,
   EventTimeReference,
   EventType,
+  FREQUENCY_PERIOD_MS,
   MAX_EVENT_RECURRENT,
   MonthMask,
   Months,
@@ -143,57 +144,150 @@ export function toRRule(options: RecurrentEventAttributes): RRule | null {
     return null
   }
 
+  // Omit byweekday/bymonth entirely when the mask is 0 so rrule's
+  // parseoptions can infer the default from dtstart. Passing [] instead
+  // of undefined makes rrule treat the field as "present but matches
+  // nothing", which for WEEKLY produces an empty expansion.
   return new RRule({
     dtstart: options.start_at,
     freq: RRule[options.recurrent_frequency],
     interval: options.recurrent_interval || 1,
     until: options.recurrent_until,
     count: options.recurrent_count,
-    byweekday: toRRuleWeekdays(options.recurrent_weekday_mask),
-    bymonth: toRRuleMonths(options.recurrent_month_mask),
+    byweekday: options.recurrent_weekday_mask
+      ? toRRuleWeekdays(options.recurrent_weekday_mask)
+      : undefined,
+    bymonth: options.recurrent_month_mask
+      ? toRRuleMonths(options.recurrent_month_mask)
+      : undefined,
     bysetpos: options.recurrent_setpos,
     bymonthday: options.recurrent_monthday,
   })
 }
 
+/**
+ * Expand a recurrence rule into the next `MAX_EVENT_RECURRENT` future
+ * occurrences. Used to materialize the `recurrent_dates` column during
+ * event create / update and during the `updateNextStartAt` cron.
+ *
+ * Returns `[]` when the rule is incomplete (no frequency, no count /
+ * until, etc. — see `toRRule`), or when the rule has already ended
+ * (`recurrent_until` is in the past). In those cases, callers are
+ * expected to fall back to `[start_at]` via
+ * `calculateRecurrentProperties`.
+ *
+ * Past occurrences are iterated internally by rrule but never
+ * allocated, so this function is safe to call on rules whose
+ * `start_at` is years in the past. CPU cost is still
+ * `O((now - start_at) / period)` in that case — route handlers reject
+ * rules above `MAX_RECURRENT_PAST_ITERATIONS` before calling this.
+ *
+ * @param options - Recurrence rule attributes. `start_at` supplies the
+ *   time-of-day for every emitted date.
+ * @returns Up to `MAX_EVENT_RECURRENT` future `Date` objects in
+ *   ascending order, each carrying the time-of-day from `start_at`.
+ */
 export function futureRecurrentDates(
   options: RecurrentEventAttributes
 ): Date[] {
-  const now = Date.now()
-  let recurrentCount = 0
-
-  return toRRuleDates(options, (date) => {
-    if (date.getTime() >= now) {
-      recurrentCount++
-    }
-
-    if (recurrentCount > MAX_EVENT_RECURRENT) {
-      return false
-    }
-
-    return true
-  }).filter(
-    (date) => date.getTime() >= Math.max(now, options.start_at.getTime())
-  )
-}
-
-export function toRRuleDates(
-  options: RecurrentEventAttributes,
-  iterator?: (d: Date, len: number) => boolean
-): Date[] {
   const rrule = toRRule(options)
-
-  if (rrule) {
-    return rrule.all(iterator).map((date) => {
-      date.setUTCHours(options.start_at.getUTCHours())
-      date.setUTCMinutes(options.start_at.getUTCMinutes())
-      date.setUTCSeconds(options.start_at.getUTCSeconds())
-      date.setUTCMilliseconds(options.start_at.getUTCMilliseconds())
-      return date
-    })
+  if (!rrule) {
+    return []
   }
 
-  return []
+  const now = new Date()
+  // rrule.between requires a concrete upper bound. When the rule ends
+  // via `count` instead of `until`, use the library's MAXYEAR (9999) as
+  // a sentinel — rrule will stop on count or on the iterator long
+  // before then.
+  const end = options.recurrent_until ?? new Date(Date.UTC(9999, 11, 31))
+  // The rule has already ended (recurrent_until is in the past). Return
+  // empty and let calculateRecurrentProperties fall back to [start_at].
+  // The updateNextStartAt cron filters these out via `finish_at > now()`
+  // so they do not get regenerated forever.
+  if (end < now) {
+    return []
+  }
+
+  // rrule iterates internally from dtstart forward, but for `between`
+  // it drops past occurrences in accept() before they reach our
+  // iterator — so past dates are never allocated into the result array.
+  // Our iterator only sees future dates and caps them at
+  // MAX_EVENT_RECURRENT via the `len` argument (current result length
+  // before push).
+  const dates = rrule.between(
+    now,
+    end,
+    /* inc */ true,
+    (_date, len) => len < MAX_EVENT_RECURRENT
+  )
+
+  return dates.map((date) => {
+    date.setUTCHours(options.start_at.getUTCHours())
+    date.setUTCMinutes(options.start_at.getUTCMinutes())
+    date.setUTCSeconds(options.start_at.getUTCSeconds())
+    date.setUTCMilliseconds(options.start_at.getUTCMilliseconds())
+    return date
+  })
+}
+
+/**
+ * Upper-bound estimate of how many past occurrences rrule will walk
+ * through when expanding the rule — i.e.
+ * `(min(now, recurrent_until) - start_at) / (interval * frequency)`,
+ * capped by `recurrent_count` when present.
+ *
+ * Used by the route handlers (`createEvent`, `updateEvent`) and the
+ * `updateNextStartAt` cron to reject or skip rules whose expansion
+ * would burn excessive CPU walking from `start_at` to `now` before
+ * producing any future dates. The check is typically compared against
+ * `MAX_RECURRENT_PAST_ITERATIONS`.
+ *
+ * Returns `0` when the rule is non-recurrent, missing a frequency, or
+ * missing a terminator (`count` / `until`) — mirrors `toRRule`'s gate
+ * so a rule that won't actually iterate is never flagged.
+ *
+ * @param options - Recurrence rule attributes. Only the fields listed
+ *   in the `Pick` are read.
+ * @returns An upper bound (may be fractional); `0` if the rule won't
+ *   iterate.
+ */
+export function estimateRecurrentPastIterations(
+  options: Pick<
+    RecurrentEventAttributes,
+    | "recurrent"
+    | "recurrent_frequency"
+    | "recurrent_interval"
+    | "recurrent_count"
+    | "recurrent_until"
+    | "start_at"
+  >
+): number {
+  if (!options.recurrent || !options.recurrent_frequency) {
+    return 0
+  }
+  // Mirror toRRule's gate: without a terminating condition rrule is
+  // never built and the rule silently becomes non-recurrent, so there
+  // are no iterations to worry about.
+  if (!options.recurrent_count && !options.recurrent_until) {
+    return 0
+  }
+  const period =
+    FREQUENCY_PERIOD_MS[options.recurrent_frequency] *
+    (options.recurrent_interval || 1)
+  // rrule iterates from dtstart until it reaches the first of:
+  // recurrent_until, recurrent_count, or our iterator callback. Bound
+  // the time span by min(now, recurrent_until) so a rule whose until
+  // is already in the past isn't over-estimated as if it ran up to
+  // today.
+  const now = Date.now()
+  const timeBound = options.recurrent_until
+    ? Math.min(now, options.recurrent_until.getTime())
+    : now
+  const span = Math.max(0, timeBound - options.start_at.getTime())
+  const byTime = span / period
+  const byCount = options.recurrent_count ?? Number.POSITIVE_INFINITY
+  return Math.min(byTime, byCount)
 }
 
 export function toRRuleMonths(mask: number) {

--- a/src/hooks/useEventEditor.ts
+++ b/src/hooks/useEventEditor.ts
@@ -350,10 +350,20 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
   }
 
   function handleChangeInterval(value?: string) {
-    const interval = Number(value)
+    // The backend schema requires integer recurrent_interval (fractional
+    // values bypass rrule's count/interval semantics), so coerce here to
+    // match. The HTML <input type="number"> has step="1" as a hint but
+    // users can still paste decimals; Math.trunc makes the UI robust.
+    // Upper bound mirrors newEventSchema (max: 1000) so a pasted value
+    // doesn't get silently rejected by the server on submit.
+    const interval = Math.trunc(Number(value))
     if (value === "") {
       setValue("recurrent_interval", value as any)
-    } else if (interval >= 1) {
+    } else if (
+      Number.isFinite(interval) &&
+      interval >= 1 &&
+      interval <= 1000
+    ) {
       setValue("recurrent_interval", interval)
     }
   }
@@ -437,10 +447,15 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
   }
 
   function handleChangeRecurrentCount(value?: string) {
-    const recurrent_count = Number(value)
+    // See handleChangeInterval — backend requires integer.
+    const recurrent_count = Math.trunc(Number(value))
     if (value === "") {
       setValue("recurrent_count", value as any)
-    } else if (recurrent_count > 0 && recurrent_count <= MAX_EVENT_RECURRENT) {
+    } else if (
+      Number.isFinite(recurrent_count) &&
+      recurrent_count > 0 &&
+      recurrent_count <= MAX_EVENT_RECURRENT
+    ) {
       setValue("recurrent_count", recurrent_count)
     }
   }

--- a/src/hooks/useEventEditor.ts
+++ b/src/hooks/useEventEditor.ts
@@ -359,11 +359,7 @@ export default function useEventEditor(defaultEvent: Partial<EditEvent> = {}) {
     const interval = Math.trunc(Number(value))
     if (value === "") {
       setValue("recurrent_interval", value as any)
-    } else if (
-      Number.isFinite(interval) &&
-      interval >= 1 &&
-      interval <= 1000
-    ) {
+    } else if (Number.isFinite(interval) && interval >= 1 && interval <= 1000) {
       setValue("recurrent_interval", interval)
     }
   }

--- a/src/pages/submit/index.tsx
+++ b/src/pages/submit/index.tsx
@@ -929,6 +929,9 @@ export default function SubmitPage() {
                     <Field
                       label="&nbsp;"
                       type="number"
+                      step={1}
+                      min={1}
+                      max={1000}
                       name="recurrent_interval"
                       error={!!errors["recurrent_interval"]}
                       message={errors["recurrent_interval"]}
@@ -1163,6 +1166,9 @@ export default function SubmitPage() {
                       label="&nbsp;"
                       name="recurrent_count"
                       type="number"
+                      step={1}
+                      min={1}
+                      max={MAX_EVENT_RECURRENT}
                       error={!!errors["recurrent_count"]}
                       message={errors["recurrent_count"]}
                       value={editing.recurrent_count}


### PR DESCRIPTION
## Summary

- Caps the work `rrule` has to do when expanding a recurrence so that expansion cost stays proportional to the 10 future occurrences the product actually renders, rather than to the full span between `start_at` and the rule's end.
- Tightens the input contract on recurrence fields (frequencies, integer types, upper bounds) in the schema and in the UI so valid submissions always produce valid API payloads.
- Fixes a pre-existing `rrule` default-inference quirk that silently produced empty expansions for weekly/monthly rules created with no explicit weekday/month mask.

## Why

Recurrence expansion ran from `dtstart` forward via `rrule.all(iterator)` and pushed every generated date — past and future — into an array before the caller filtered. For a rule anchored far in the past, that materialized large arrays of `Date` objects per request before the 10 future ones could be isolated. The `updateNextStartAt` cron re-ran the same expansion every minute for every recurrent-finished event. Combined with permissive input validation, the end-to-end cost of processing a single recurrence rule was unbounded in both memory and CPU.

Separately, the UI and backend had drifted on what shape of recurrence was accepted — the frontend form only offered daily/weekly/monthly, but the API accepted sub-hourly and fractional values, producing rules that were either nonsensical or wildly expensive to expand.

## How

### Expansion

- `futureRecurrentDates` switched from `rrule.all(iterator)` to `rrule.between(now, until, true, iterator)`. Past occurrences are still iterated internally by `rrule` but are dropped in its `accept()` before reaching our iterator, so the result array never grows past `MAX_EVENT_RECURRENT`.
- In `toRRule`, when `recurrent_weekday_mask` or `recurrent_month_mask` is `0`, pass `undefined` to `rrule` instead of `[]`. `rrule`'s `parseoptions` uses `isPresent` (not `notEmpty`) on these fields, so an empty array suppressed its own default inference from `dtstart` — producing zero occurrences for weekly/monthly rules with no explicit mask. Affected rows will self-heal the next time they're touched (or via cron).

### Input validation

- `newEventSchema` `recurrent_frequency` now restricted to `AllowedInputFrequencies` (HOURLY / DAILY / WEEKLY / MONTHLY / YEARLY). `MINUTELY` / `SECONDLY` are rejected.
- `recurrent_interval`, `recurrent_count`, and the mask / setpos / monthday fields switched to `type: "integer"` in the JSON schema. Fractional values now rejected at the boundary.
- `recurrent_interval` and `recurrent_count` gained `maximum: 1000` in the schema.
- `eventSchema` (response schema) keeps the full `Frequencies` list for backward compatibility when serializing any legacy rows.

### Work estimator + route / cron guards

- New `estimateRecurrentPastIterations` returns an upper-bound estimate of how many steps `rrule` will take from `start_at` to `now`, bounded by `recurrent_count` when set, and by `recurrent_until` when it's already in the past.
- `createEvent` rejects payloads whose estimate exceeds `MAX_RECURRENT_PAST_ITERATIONS` (50k) right after the duration check, before any external-API calls.
- `updateEvent` runs the same check immediately after `validateUpdateEvent`, gated on whether the request actually touches a field in `RECURRENCE_REQUEST_FIELDS` (`start_at`, `recurrent`, `recurrent_frequency`, `recurrent_interval`, `recurrent_count`, `recurrent_until`). Routine edits to existing rows whose start dates have aged past the cap keep working; only edits that introduce or modify the recurrence are subject to the check. Placement above the external-API block (`Catalyst.getProfiles`, `Land.getTile`, `Places.getPlaceByPosition`) means rejected PATCHes fail fast without upstream cost.
- `updateNextStartAt` cron runs the same estimate per event and skips any row over the cap with a log message. The row's `recurrent_dates` is left untouched so a later fix to the rule can bring it back on-track.

### UI parity

- `handleChangeInterval` and `handleChangeRecurrentCount` in `useEventEditor` coerce via `Math.trunc(Number(value))` and guard with `Number.isFinite`. `recurrent_interval` is additionally clamped to `[1, 1000]` in the handler so pasted out-of-range values don't silently drop into state.
- The corresponding HTML inputs in `pages/submit/index.tsx` gained `step={1}`, `min={1}`, and a `max` attribute (`1000` for interval, `MAX_EVENT_RECURRENT` for count) so the browser provides native validation and spinner step.

### Docs + dead code

- JSDoc added to the two public recurrence helpers (`futureRecurrentDates`, `estimateRecurrentPastIterations`) documenting the contract and when they return empty.
- Removed `toRRuleDates` — no longer called after the `rrule.between` refactor.

## Test plan

- [x] `npx jest src/` — 130 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] New coverage: 8 schema tests (frequency / integer / boundary / fractional-rejection), 5 `futureRecurrentDates` edge cases, 10 `estimateRecurrentPastIterations` cases, 3 `updateEvent` grandfathering scenarios including fail-fast ordering against `Catalyst.getProfiles`, 3 cron scenarios including a mixed-batch skip test
- [x] Before deploying, run the pre-existing-data checks against production:
    - `SELECT COUNT(*) FROM events WHERE recurrent IS TRUE AND recurrent_frequency IN ('MINUTELY', 'SECONDLY');`
    - `SELECT COUNT(*) FROM events WHERE recurrent IS TRUE AND (recurrent_count > 1000 OR recurrent_interval > 1000);`
    - `SELECT COUNT(*) FROM events WHERE recurrent IS TRUE AND recurrent_interval = 0;`
  All three should return 0 for a clean deploy.
- [ ] Manually create and edit a daily / weekly / monthly event via the submit form and confirm behavior is unchanged for normal cases
- [ ] Confirm the form rejects intervals > 1000 and non-integer counts before submit (native browser validation + handler-level guards)