### PR TITLE
feat: add admin API for event moderation via bearer token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ ADMIN_ADDRESSES=0xffffffffffffffffffffffffffffffffffffffff
 
 # slack hook to report events updates
 SLACK_WEBHOOK=
+EVENTS_ADMIN_AUTH_TOKEN=<PLACEHOLDER>
 
 # aws access: should have permission to send email and edit a bucket
 AWS_REGION=

--- a/README.md
+++ b/README.md
@@ -142,22 +142,23 @@ cp .env.example .env.development
 
 Required environment variables:
 
-| Variable                      | Description                                    | Example                                             |
-| ----------------------------- | ---------------------------------------------- | --------------------------------------------------- |
-| `CONNECTION_STRING`           | PostgreSQL connection string                   | `postgres://user:pass@localhost:5432/events`        |
-| `ADMIN_ADDRESSES`             | Comma-separated list of admin wallet addresses | `0xabc...,0xdef...`                                 |
-| `AWS_REGION`                  | AWS region for S3 and SNS                      | `us-east-1`                                         |
-| `AWS_ACCESS_KEY`              | AWS access key ID                              | -                                                   |
-| `AWS_ACCESS_SECRET`           | AWS secret access key                          | -                                                   |
-| `AWS_BUCKET_NAME`             | S3 bucket for event images                     | `events.decentraland.zone`                          |
-| `AWS_BUCKET_URL`              | Public URL for S3 bucket                       | `https://s3.amazonaws.com/...`                      |
-| `WEB_PUSH_SECRET`             | VAPID private key for web push                 | Generate with `web-push generate-vapid-keys`        |
-| `GATSBY_WEB_PUSH_KEY`         | VAPID public key for web push                  | Generate with `web-push generate-vapid-keys`        |
-| `GATSBY_DECENTRALAND_URL`     | Decentraland play URL                          | `https://play.decentraland.org`                     |
-| `GATSBY_COMMUNITIES_API_URL`  | Communities API URL                            | `https://social-api.decentraland.zone`              |
-| `NOTIFICATION_SERVICE_URL`    | Notification service URL                       | `https://notifications-processor.decentraland.zone` |
-| `NOTIFICATION_SERVICE_TOKEN`  | Auth token for notification service            | -                                                   |
-| `COMMUNITIES_API_ADMIN_TOKEN` | Admin token for communities API                | -                                                   |
+| Variable                      | Description                                               | Example                                             |
+| ----------------------------- | --------------------------------------------------------- | --------------------------------------------------- |
+| `CONNECTION_STRING`           | PostgreSQL connection string                              | `postgres://user:pass@localhost:5432/events`        |
+| `ADMIN_ADDRESSES`             | Comma-separated list of admin wallet addresses            | `0xabc...,0xdef...`                                 |
+| `EVENTS_ADMIN_AUTH_TOKEN`     | Bearer token for service-to-service event admin endpoints | -                                                   |
+| `AWS_REGION`                  | AWS region for S3 and SNS                                 | `us-east-1`                                         |
+| `AWS_ACCESS_KEY`              | AWS access key ID                                         | -                                                   |
+| `AWS_ACCESS_SECRET`           | AWS secret access key                                     | -                                                   |
+| `AWS_BUCKET_NAME`             | S3 bucket for event images                                | `events.decentraland.zone`                          |
+| `AWS_BUCKET_URL`              | Public URL for S3 bucket                                  | `https://s3.amazonaws.com/...`                      |
+| `WEB_PUSH_SECRET`             | VAPID private key for web push                            | Generate with `web-push generate-vapid-keys`        |
+| `GATSBY_WEB_PUSH_KEY`         | VAPID public key for web push                             | Generate with `web-push generate-vapid-keys`        |
+| `GATSBY_DECENTRALAND_URL`     | Decentraland play URL                                     | `https://play.decentraland.org`                     |
+| `GATSBY_COMMUNITIES_API_URL`  | Communities API URL                                       | `https://social-api.decentraland.zone`              |
+| `NOTIFICATION_SERVICE_URL`    | Notification service URL                                  | `https://notifications-processor.decentraland.zone` |
+| `NOTIFICATION_SERVICE_TOKEN`  | Auth token for notification service                       | -                                                   |
+| `COMMUNITIES_API_ADMIN_TOKEN` | Admin token for communities API                           | -                                                   |
 
 See `.env.example` for a complete list of configuration options.
 

--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -52,6 +52,7 @@ erDiagram
     UUID[] schedules
     TEXT approved_by
     TEXT rejected_by
+    TEXT rejection_reason
     BOOLEAN world
     TEXT place_id
     TEXT community_id
@@ -162,6 +163,7 @@ Stores all event information including one-time and recurrent events with locati
 | `rejected`               | BOOLEAN       | NOT NULL | Rejection status by moderator (default: false)                  |
 | `approved_by`            | TEXT          | NULL     | Moderator wallet address who approved. Stored in lowercase      |
 | `rejected_by`            | TEXT          | NULL     | Moderator wallet address who rejected. Stored in lowercase      |
+| `rejection_reason`       | TEXT          | NULL     | Reason provided by a moderator or service when rejecting        |
 | `highlighted`            | BOOLEAN       | NOT NULL | Featured/highlighted status (default: false)                    |
 | `trending`               | BOOLEAN       | NOT NULL | Trending status calculated algorithmically (default: false)     |
 | `recurrent`              | BOOLEAN       | NOT NULL | Whether event is recurrent (default: false)                     |
@@ -209,7 +211,7 @@ Stores all event information including one-time and recurrent events with locati
 
 ### Business Rules
 
-- **Address normalization**: Wallet addresses in `user`, `approved_by`, and `rejected_by` fields must be stored in lowercase
+- **Address normalization**: Wallet addresses in `user`, `approved_by`, and `rejected_by` fields must be stored in lowercase; service actors may also appear in moderator fields
 - **Attendee limit**: The `latest_attendees` array is capped at a configurable limit for performance
 - **Default coordinates**: Coordinates (0,0) represent Decentraland's Genesis Plaza
 - **Textsearch updates**: The `textsearch` column is automatically updated via trigger when `name` or `description` changes

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -460,7 +460,7 @@ paths:
         When called with the service bearer token (`Authorization: Bearer ...`), permission
         checks are bypassed and the request body identifies the actor via the `actor` field.
         The body may alternatively contain only approval/rejection fields
-        (`approved`, `rejected`, `rejection_reason`) to transition the event state without
+        (`approved`, `rejected`, `reason`) to transition the event state without
         re-validating every editable attribute — see `EventAdminActor` and `EventAdminReject`.
       operationId: updateEvent
       security:
@@ -1838,6 +1838,29 @@ components:
           nullable: true
         recurrent_monthday:
           type: integer
+          nullable: true
+        contact:
+          type: object
+          nullable: true
+        details:
+          type: object
+          nullable: true
+        community_id:
+          type: string
+          format: uuid
+          nullable: true
+        highlighted:
+          type: boolean
+        trending:
+          type: boolean
+        schedules:
+          type: array
+          items:
+            type: string
+            format: uuid
+        url:
+          type: string
+          format: uri
           nullable: true
 
     EventAttendee:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -388,6 +388,67 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /events/admin:
+    get:
+      tags:
+        - Events
+      summary: List events as an admin service
+      description: Lists events, including pending or rejected rows, using the service bearer token.
+      operationId: events_adminListEvents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: approved
+          in: query
+          required: false
+          description: Filter by approval state
+          schema:
+            type: boolean
+        - name: rejected
+          in: query
+          required: false
+          description: Filter by rejection state
+          schema:
+            type: boolean
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: List of events
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Event'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
   /events/{event_id}:
     get:
       tags:
@@ -470,6 +531,267 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
+  /events/{event_id}/approved:
+    put:
+      tags:
+        - Events
+      summary: Approve an event as an admin service
+      description: Approves a pending event using the service bearer token.
+      operationId: events_approveEvent
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Event UUID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventAdminActor'
+      responses:
+        '200':
+          description: Event approved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/Event'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+    delete:
+      tags:
+        - Events
+      summary: Remove admin approval from an event
+      description: Clears the approved flag without changing rejected state.
+      operationId: events_unapproveEvent
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Event UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Event approval removed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/Event'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /events/{event_id}/rejected:
+    put:
+      tags:
+        - Events
+      summary: Reject an event as an admin service
+      description: Rejects an event, stores the rejection reason, and clears approval and promotional flags.
+      operationId: events_rejectEvent
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Event UUID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventAdminReject'
+      responses:
+        '200':
+          description: Event rejected successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/Event'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+    delete:
+      tags:
+        - Events
+      summary: Remove admin rejection from an event
+      description: Clears the rejected flag and rejection reason.
+      operationId: events_unrejectEvent
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Event UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Event rejection removed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/Event'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /events/{event_id}/admin:
+    get:
+      tags:
+        - Events
+      summary: Get event as an admin service
+      description: Retrieves an event by ID regardless of approval state using the service bearer token.
+      operationId: events_adminGetEvent
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Event UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Event details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/Event'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+    patch:
+      tags:
+        - Events
+      summary: Update event fields as an admin service
+      description: Updates event-editable fields using the service bearer token.
+      operationId: events_adminUpdateEvent
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Event UUID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventAdminUpdate'
+      responses:
+        '200':
+          description: Event updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/Event'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
 
   /events/{event_id}/attendees:
     get:
@@ -1151,6 +1473,12 @@ paths:
                 $ref: '#/components/schemas/Error'
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: service-token
+
   schemas:
     Event:
       type: object
@@ -1282,16 +1610,19 @@ components:
           type: boolean
           description: Whether the event has been rejected by a moderator
           default: false
+        rejection_reason:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: Reason provided by a moderator or service when rejecting the event
         approved_by:
           type: string
           nullable: true
-          pattern: '^0x[a-fA-F0-9]{40}$'
-          description: Ethereum address of approver
+          description: Wallet address or service actor that approved the event
         rejected_by:
           type: string
           nullable: true
-          pattern: '^0x[a-fA-F0-9]{40}$'
-          description: Ethereum address of rejector
+          description: Wallet address or service actor that rejected the event
         highlighted:
           type: boolean
           description: Whether the event is highlighted in the UI
@@ -1668,10 +1999,113 @@ components:
           type: boolean
         rejected:
           type: boolean
+        rejection_reason:
+          type: string
+          nullable: true
+          maxLength: 500
         highlighted:
           type: boolean
         trending:
           type: boolean
+
+    EventAdminActor:
+      type: object
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+          maxLength: 42
+          default: jarvis-agent
+          description: Service actor recorded in approved_by or rejected_by
+
+    EventAdminReject:
+      allOf:
+        - $ref: '#/components/schemas/EventAdminActor'
+        - type: object
+          required:
+            - reason
+          properties:
+            reason:
+              type: string
+              minLength: 1
+              maxLength: 500
+              description: Human-readable reason stored as rejection_reason
+
+    EventAdminUpdate:
+      type: object
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+          maxLength: 42
+          default: jarvis-agent
+        name:
+          type: string
+          minLength: 1
+          maxLength: 150
+        description:
+          type: string
+          nullable: true
+          maxLength: 5000
+        image:
+          type: string
+          format: uri
+          nullable: true
+        image_vertical:
+          type: string
+          format: uri
+          nullable: true
+        start_at:
+          type: string
+          format: date-time
+        duration:
+          type: integer
+          minimum: 0
+        all_day:
+          type: boolean
+        x:
+          type: integer
+          minimum: -170
+          maximum: 170
+        y:
+          type: integer
+          minimum: -170
+          maximum: 170
+        server:
+          type: string
+          nullable: true
+        categories:
+          type: array
+          nullable: true
+          items:
+            type: string
+        world:
+          type: boolean
+        recurrent:
+          type: boolean
+        recurrent_frequency:
+          type: string
+          nullable: true
+          enum: [YEARLY, MONTHLY, WEEKLY, DAILY, HOURLY]
+        recurrent_interval:
+          type: integer
+        recurrent_count:
+          type: integer
+          nullable: true
+        recurrent_until:
+          type: string
+          format: date-time
+          nullable: true
+        recurrent_weekday_mask:
+          type: integer
+        recurrent_month_mask:
+          type: integer
+        recurrent_setpos:
+          type: integer
+          nullable: true
+        recurrent_monthday:
+          type: integer
+          nullable: true
 
     EventAttendee:
       type: object
@@ -2081,3 +2515,12 @@ components:
             ok: false
             error: "Internal server error"
 
+    ServiceUnavailable:
+      description: Service unavailable - endpoint disabled or dependency unavailable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            ok: false
+            error: "EVENTS_ADMIN_AUTH_TOKEN is not configured; events admin endpoints are disabled"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1620,6 +1620,7 @@ components:
 
     EventUpdate:
       type: object
+      additionalProperties: false
       description: Schema for updating an event (all fields optional)
       properties:
         name:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -85,9 +85,27 @@ paths:
         Retrieves a list of events based on various filters. By default returns active events
         (current and future) sorted by start date ascending. Supports filtering by location,
         creator, categories, schedules, and more.
+
+        When called with the service bearer token (`Authorization: Bearer ...`), the response
+        includes pending and rejected rows and the `approved` / `rejected` query parameters are
+        honored as explicit state filters.
       operationId: getEvents
-      security: []
+      security:
+        - {}
+        - bearerAuth: []
       parameters:
+        - name: approved
+          in: query
+          required: false
+          description: Admin-only. Filter by approval state (only applied with bearer auth).
+          schema:
+            type: boolean
+        - name: rejected
+          in: query
+          required: false
+          description: Admin-only. Filter by rejection state (only applied with bearer auth).
+          schema:
+            type: boolean
         - name: limit
           in: query
           description: Maximum number of events to return
@@ -388,67 +406,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /events/admin:
-    get:
-      tags:
-        - Events
-      summary: List events as an admin service
-      description: Lists events, including pending or rejected rows, using the service bearer token.
-      operationId: events_adminListEvents
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: approved
-          in: query
-          required: false
-          description: Filter by approval state
-          schema:
-            type: boolean
-        - name: rejected
-          in: query
-          required: false
-          description: Filter by rejection state
-          schema:
-            type: boolean
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 500
-            default: 100
-        - name: offset
-          in: query
-          required: false
-          schema:
-            type: integer
-            minimum: 0
-            default: 0
-      responses:
-        '200':
-          description: List of events
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Event'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-
   /events/{event_id}:
     get:
       tags:
@@ -457,8 +414,13 @@ paths:
       description: |
         Retrieves detailed information about a specific event.
         If authenticated, includes whether the user is attending.
+
+        When called with the service bearer token (`Authorization: Bearer ...`), pending and
+        rejected events are returned regardless of approval state.
       operationId: getEventById
-      security: []
+      security:
+        - {}
+        - bearerAuth: []
       parameters:
         - name: event_id
           in: path
@@ -484,6 +446,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
 
     patch:
       tags:
@@ -492,8 +456,16 @@ paths:
       description: |
         Updates an existing event. Users can only update their own events unless they
         have special permissions. Some fields require admin permissions.
+
+        When called with the service bearer token (`Authorization: Bearer ...`), permission
+        checks are bypassed and the request body identifies the actor via the `actor` field.
+        The body may alternatively contain only approval/rejection fields
+        (`approved`, `rejected`, `rejection_reason`) to transition the event state without
+        re-validating every editable attribute — see `EventAdminActor` and `EventAdminReject`.
       operationId: updateEvent
-      security: []
+      security:
+        - {}
+        - bearerAuth: []
       parameters:
         - name: event_id
           in: path
@@ -507,7 +479,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EventUpdate'
+              oneOf:
+                - $ref: '#/components/schemas/EventUpdate'
+                - $ref: '#/components/schemas/EventAdminUpdate'
+                - $ref: '#/components/schemas/EventAdminActor'
+                - $ref: '#/components/schemas/EventAdminReject'
       responses:
         '200':
           description: Event updated successfully
@@ -527,265 +503,6 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /events/{event_id}/approved:
-    put:
-      tags:
-        - Events
-      summary: Approve an event as an admin service
-      description: Approves a pending event using the service bearer token.
-      operationId: events_approveEvent
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: event_id
-          in: path
-          required: true
-          description: Event UUID
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EventAdminActor'
-      responses:
-        '200':
-          description: Event approved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    $ref: '#/components/schemas/Event'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-
-    delete:
-      tags:
-        - Events
-      summary: Remove admin approval from an event
-      description: Clears the approved flag without changing rejected state.
-      operationId: events_unapproveEvent
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: event_id
-          in: path
-          required: true
-          description: Event UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Event approval removed successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    $ref: '#/components/schemas/Event'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-
-  /events/{event_id}/rejected:
-    put:
-      tags:
-        - Events
-      summary: Reject an event as an admin service
-      description: Rejects an event, stores the rejection reason, and clears approval and promotional flags.
-      operationId: events_rejectEvent
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: event_id
-          in: path
-          required: true
-          description: Event UUID
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EventAdminReject'
-      responses:
-        '200':
-          description: Event rejected successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    $ref: '#/components/schemas/Event'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-
-    delete:
-      tags:
-        - Events
-      summary: Remove admin rejection from an event
-      description: Clears the rejected flag and rejection reason.
-      operationId: events_unrejectEvent
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: event_id
-          in: path
-          required: true
-          description: Event UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Event rejection removed successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    $ref: '#/components/schemas/Event'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-
-  /events/{event_id}/admin:
-    get:
-      tags:
-        - Events
-      summary: Get event as an admin service
-      description: Retrieves an event by ID regardless of approval state using the service bearer token.
-      operationId: events_adminGetEvent
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: event_id
-          in: path
-          required: true
-          description: Event UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Event details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    $ref: '#/components/schemas/Event'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-
-    patch:
-      tags:
-        - Events
-      summary: Update event fields as an admin service
-      description: Updates event-editable fields using the service bearer token.
-      operationId: events_adminUpdateEvent
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: event_id
-          in: path
-          required: true
-          description: Event UUID
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EventAdminUpdate'
-      responses:
-        '200':
-          description: Event updated successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                    example: true
-                  data:
-                    $ref: '#/components/schemas/Event'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -2011,25 +1728,41 @@ components:
     EventAdminActor:
       type: object
       additionalProperties: false
+      description: |
+        Body for admin approval state changes sent to `PATCH /events/{event_id}` with
+        bearer auth. Set `approved: true` to approve, `approved: false` to unapprove.
+        For rejection, use `EventAdminReject`.
       properties:
         actor:
           type: string
           maxLength: 42
           default: jarvis-agent
           description: Service actor recorded in approved_by or rejected_by
+        approved:
+          type: boolean
+          description: Set to true to approve, false to clear approval
 
     EventAdminReject:
       allOf:
         - $ref: '#/components/schemas/EventAdminActor'
         - type: object
+          description: |
+            Body for admin rejection state changes sent to `PATCH /events/{event_id}` with
+            bearer auth. Set `rejected: true` with a `reason` to reject, or `rejected: false`
+            (no reason required) to clear a prior rejection.
           required:
-            - reason
+            - rejected
           properties:
+            rejected:
+              type: boolean
+              description: Set to true to reject, false to clear rejection
             reason:
               type: string
               minLength: 1
               maxLength: 500
-              description: Human-readable reason stored as rejection_reason
+              description: |
+                Human-readable reason stored as rejection_reason. Required when
+                rejected=true.
 
     EventAdminUpdate:
       type: object

--- a/src/entities/Event/model.test.ts
+++ b/src/entities/Event/model.test.ts
@@ -4,6 +4,7 @@ import { EventListOptions, EventListType } from "./types"
 type SQLCondition = { text: string }
 
 const ATTENDEE_FILTER_REGEX = /a\.user\s+IS\s+NOT\s+NULL/i
+const REJECTED_FILTER_REGEX = /e\.rejected\s+IS\s+(TRUE|FALSE)/i
 
 const buildEventFilterConditions = (
   EventModel as any
@@ -17,9 +18,65 @@ function hasAttendeeFilterCondition(conditions: SQLCondition[]): boolean {
   )
 }
 
+function hasRejectedFilterCondition(conditions: SQLCondition[]): boolean {
+  return conditions.some((condition) =>
+    REJECTED_FILTER_REGEX.test(condition.text)
+  )
+}
+
 describe("EventModel.buildEventFilterConditions", () => {
   afterEach(() => {
     jest.resetAllMocks()
+  })
+
+  describe("when rejection filtering is not configured", () => {
+    let options: Partial<EventListOptions>
+
+    beforeEach(() => {
+      options = {
+        list: EventListType.All,
+      }
+    })
+
+    it("should filter out rejected events by default", () => {
+      const conditions = buildEventFilterConditions(options)
+
+      expect(hasRejectedFilterCondition(conditions)).toBe(true)
+    })
+  })
+
+  describe("when include_rejected option is true", () => {
+    let options: Partial<EventListOptions>
+
+    beforeEach(() => {
+      options = {
+        include_rejected: true,
+        list: EventListType.All,
+      }
+    })
+
+    it("should not generate a rejected filter condition", () => {
+      const conditions = buildEventFilterConditions(options)
+
+      expect(hasRejectedFilterCondition(conditions)).toBe(false)
+    })
+  })
+
+  describe("when rejected option is true", () => {
+    let options: Partial<EventListOptions>
+
+    beforeEach(() => {
+      options = {
+        rejected: true,
+        list: EventListType.All,
+      }
+    })
+
+    it("should generate a rejected filter condition", () => {
+      const conditions = buildEventFilterConditions(options)
+
+      expect(hasRejectedFilterCondition(conditions)).toBe(true)
+    })
   })
 
   describe("when only_attendee option is true", () => {

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -179,7 +179,15 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     }
 
     return [
-      SQL`e.rejected IS FALSE`,
+      options.rejected === undefined
+        ? options.include_rejected
+          ? SQL`TRUE`
+          : SQL`e.rejected IS FALSE`
+        : SQL`e.rejected IS ${SQL.raw(options.rejected ? "TRUE" : "FALSE")}`,
+      conditional(
+        options.approved !== undefined,
+        SQL`AND e.approved IS ${SQL.raw(options.approved ? "TRUE" : "FALSE")}`
+      ),
       conditional(options.list === EventListType.All, SQL``),
       conditional(
         options.list === EventListType.Active,

--- a/src/entities/Event/routes/admin.test.ts
+++ b/src/entities/Event/routes/admin.test.ts
@@ -500,6 +500,33 @@ describe("events admin endpoints", () => {
         )
       })
     })
+
+    describe("when the event was previously approved", () => {
+      it("should clear approved_by along with approved", async () => {
+        const event = createBaseEvent({
+          approved: true,
+          approved_by: "0xPreviousApprover",
+        })
+        const request = createAdminRequest({
+          actor: ACTOR,
+          reason: "Suspicious external URL",
+        })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+
+        await rejectEvent(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            approved: false,
+            approved_by: null,
+            rejected: true,
+            rejected_by: ACTOR,
+          }),
+          { id: EVENT_ID }
+        )
+      })
+    })
   })
 
   describe("unapproveEvent", () => {
@@ -624,6 +651,80 @@ describe("events admin endpoints", () => {
           }),
           { id: EVENT_ID }
         )
+      })
+    })
+
+    describe("when the body contains only state fields", () => {
+      let event: DeprecatedEventAttributes
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+      })
+
+      it("should approve the event when body is { approved: true }", async () => {
+        const request = createAdminRequest({ actor: ACTOR, approved: true })
+
+        await patchEventAdmin(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            approved: true,
+            approved_by: ACTOR,
+          }),
+          { id: EVENT_ID }
+        )
+        expect(notifyApprovedEvent).toHaveBeenCalled()
+      })
+
+      it("should reject the event when body is { rejected: true, reason }", async () => {
+        const request = createAdminRequest({
+          actor: ACTOR,
+          rejected: true,
+          reason: "Spam",
+        })
+
+        await patchEventAdmin(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            approved: false,
+            approved_by: null,
+            rejected: true,
+            rejected_by: ACTOR,
+            rejection_reason: "Spam",
+          }),
+          { id: EVENT_ID }
+        )
+        expect(notifyRejectedEvent).toHaveBeenCalled()
+      })
+
+      it("should reject the request when approved and rejected are both set", async () => {
+        const request = createAdminRequest({
+          actor: ACTOR,
+          approved: true,
+          rejected: true,
+        })
+
+        await expectRequestError(patchEventAdmin(request), 400)
+      })
+
+      it("should reject the request when approved is not a boolean", async () => {
+        const request = createAdminRequest({ approved: "yes" })
+
+        await expectRequestError(patchEventAdmin(request), 400)
+      })
+    })
+
+    describe("when the body is empty", () => {
+      beforeEach(() => {
+        const event = createBaseEvent()
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+      })
+
+      it("should reject the request with a 400", async () => {
+        await expectRequestError(patchEventAdmin(createAdminRequest({})), 400)
       })
     })
   })

--- a/src/entities/Event/routes/admin.test.ts
+++ b/src/entities/Event/routes/admin.test.ts
@@ -1,4 +1,5 @@
 import EventCategoryModel from "../../EventCategory/model"
+import { DEFAULT_PROFILE_SETTINGS } from "../../ProfileSettings/types"
 import {
   notifyApprovedEvent,
   notifyEditedEvent,
@@ -8,13 +9,13 @@ import EventModel from "../model"
 import { DeprecatedEventAttributes, EventAttributes } from "../types"
 import {
   approveEvent,
-  getEventAdmin,
-  getEventAdminList,
   patchEventAdmin,
   rejectEvent,
   unapproveEvent,
   unrejectEvent,
 } from "./admin"
+import { getEventWithOptions } from "./getEvent"
+import { getEventList } from "./getEventList"
 
 const VALID_TOKEN = "test-events-admin-token"
 const EVENT_ID = "550e8400-e29b-41d4-a716-446655440000"
@@ -114,6 +115,13 @@ jest.mock("../../EventCategory/model", () => ({
   default: {
     validateCategories: jest.fn(),
   },
+}))
+
+jest.mock("../../ProfileSettings/routes/getAuthProfileSettings", () => ({
+  getAuthProfileSettings: jest.fn().mockResolvedValue({
+    permissions: [],
+    user: "admin-service",
+  }),
 }))
 
 jest.mock("../../Slack/utils", () => ({
@@ -386,7 +394,7 @@ describe("events admin endpoints", () => {
     })
   })
 
-  describe("getEventAdmin", () => {
+  describe("getEventWithOptions in admin mode", () => {
     describe("when the event exists", () => {
       let event: DeprecatedEventAttributes
       let request: ReturnType<typeof createAdminRequest>
@@ -398,14 +406,21 @@ describe("events admin endpoints", () => {
       })
 
       it("should return the event even when it is pending", async () => {
-        const response = await getEventAdmin(request)
+        const response = await getEventWithOptions(request, {
+          includePending: true,
+          includeRejected: true,
+          profileForEvent: (event) => ({
+            ...DEFAULT_PROFILE_SETTINGS,
+            user: event.user,
+          }),
+        })
 
         expect(response).toEqual(expect.objectContaining({ id: EVENT_ID }))
       })
     })
   })
 
-  describe("getEventAdminList", () => {
+  describe("getEventList in admin mode", () => {
     describe("when filtering pending events", () => {
       let event: DeprecatedEventAttributes
       let request: Record<string, unknown>
@@ -419,7 +434,7 @@ describe("events admin endpoints", () => {
       })
 
       it("should query events with pending filters and allow pending rows", async () => {
-        await getEventAdminList(request as any)
+        await getEventList(request as any, { admin: true })
 
         expect(EventModel.getEvents).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -427,6 +442,41 @@ describe("events admin endpoints", () => {
             include_rejected: true,
             approved: false,
             rejected: false,
+          })
+        )
+      })
+    })
+
+    describe("when regular list filters are provided", () => {
+      let event: DeprecatedEventAttributes
+      let request: Record<string, unknown>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = {
+          query: {
+            approved: "true",
+            creator: "0x1111111111111111111111111111111111111111",
+            from: "2030-01-01T00:00:00.000Z",
+            search: "music",
+            to: "2030-01-31T00:00:00.000Z",
+            world: "false",
+          },
+        }
+        ;(EventModel.getEvents as jest.Mock).mockResolvedValueOnce([event])
+      })
+
+      it("should preserve normal filters and add admin visibility filters", async () => {
+        await getEventList(request as any, { admin: true })
+
+        expect(EventModel.getEvents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            allow_pending: true,
+            approved: true,
+            creator: "0x1111111111111111111111111111111111111111",
+            include_rejected: true,
+            search: "music",
+            world: false,
           })
         )
       })
@@ -445,7 +495,7 @@ describe("events admin endpoints", () => {
       })
 
       it("should include rejected rows in the admin query", async () => {
-        await getEventAdminList(request as any)
+        await getEventList(request as any, { admin: true })
 
         expect(EventModel.getEvents).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/src/entities/Event/routes/admin.test.ts
+++ b/src/entities/Event/routes/admin.test.ts
@@ -1,0 +1,630 @@
+import EventCategoryModel from "../../EventCategory/model"
+import {
+  notifyApprovedEvent,
+  notifyEditedEvent,
+  notifyRejectedEvent,
+} from "../../Slack/utils"
+import EventModel from "../model"
+import { DeprecatedEventAttributes, EventAttributes } from "../types"
+import {
+  approveEvent,
+  getEventAdmin,
+  getEventAdminList,
+  patchEventAdmin,
+  rejectEvent,
+  unapproveEvent,
+  unrejectEvent,
+} from "./admin"
+
+const VALID_TOKEN = "test-events-admin-token"
+const EVENT_ID = "550e8400-e29b-41d4-a716-446655440000"
+const ACTOR = "jarvis-agent"
+
+let mockEnvToken: string | undefined = VALID_TOKEN
+const mockGetProfiles = jest.fn().mockResolvedValue([])
+
+jest.mock("decentraland-gatsby/dist/utils/env", () => {
+  return jest.fn((key: string, defaultValue?: string) => {
+    if (key === "EVENTS_ADMIN_AUTH_TOKEN") {
+      return mockEnvToken ?? defaultValue
+    }
+    return defaultValue
+  })
+})
+
+jest.mock("@dcl/schemas/dist/dapps/world", () => ({
+  isInsideWorldLimits: () => true,
+}))
+
+jest.mock("decentraland-gatsby/dist/utils/api/API", () => {
+  class MockAPI {
+    static catch = () => Promise.resolve(null)
+  }
+  return MockAPI
+})
+
+jest.mock("decentraland-gatsby/dist/utils/api/Catalyst", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({ getProfiles: mockGetProfiles }),
+  },
+}))
+
+jest.mock("decentraland-gatsby/dist/utils/api/Land", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getTile: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../../../api/Places", () => ({
+  __esModule: true,
+  default: {
+    get: () => ({
+      getPlaceByPosition: () => Promise.resolve(null),
+      getWorldByName: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../utils", () => {
+  const actual = jest.requireActual("../utils")
+  return {
+    ...actual,
+    calculateRecurrentProperties: () => ({
+      recurrent_dates: [new Date("2030-01-01T00:00:00Z")],
+      finish_at: new Date("2030-01-01T01:00:00Z"),
+    }),
+    estimateRecurrentPastIterations: () => 0,
+    eventTargetUrl: () => "https://decentraland.org/jump?position=0,0",
+    validateImageUrl: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+jest.mock("../model", () => ({
+  __esModule: true,
+  default: {
+    findOne: jest.fn(),
+    getEvents: jest.fn(),
+    update: jest.fn(),
+    build: jest.fn((event) =>
+      event
+        ? {
+            ...event,
+            scene_name: event.estate_name,
+            coordinates: [event.x, event.y],
+          }
+        : event
+    ),
+    textsearch: jest.fn(() => null),
+    selectNextStartAt: jest.fn(() => new Date("2030-01-01T00:00:00Z")),
+    toPublic: jest.fn((event) => ({
+      ...event,
+      attending: false,
+      live: false,
+      position: [event.x, event.y],
+    })),
+  },
+}))
+
+jest.mock("../../EventCategory/model", () => ({
+  __esModule: true,
+  default: {
+    validateCategories: jest.fn(),
+  },
+}))
+
+jest.mock("../../Slack/utils", () => ({
+  notifyApprovedEvent: jest.fn(),
+  notifyEditedEvent: jest.fn(),
+  notifyRejectedEvent: jest.fn(),
+}))
+
+function createBaseEvent(
+  overrides: Partial<EventAttributes> = {}
+): DeprecatedEventAttributes {
+  const startAt = new Date("2030-01-01T00:00:00Z")
+  return {
+    id: EVENT_ID,
+    name: "Original Event",
+    image: "https://example.com/image.png",
+    image_vertical: null,
+    description: "Original description",
+    start_at: startAt,
+    finish_at: new Date("2030-01-01T01:00:00Z"),
+    next_start_at: startAt,
+    next_finish_at: new Date("2030-01-01T01:00:00Z"),
+    duration: 3600000,
+    all_day: false,
+    x: 0,
+    y: 0,
+    server: null,
+    url: "https://decentraland.org/jump?position=0,0",
+    user: "0x1111111111111111111111111111111111111111",
+    estate_id: null,
+    estate_name: null,
+    user_name: "OriginalUser",
+    approved: false,
+    rejected: false,
+    highlighted: false,
+    trending: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+    recurrent: false,
+    recurrent_frequency: null,
+    recurrent_setpos: null,
+    recurrent_monthday: null,
+    recurrent_weekday_mask: 0,
+    recurrent_month_mask: 0,
+    recurrent_interval: 1,
+    recurrent_count: null,
+    recurrent_until: null,
+    recurrent_dates: [startAt],
+    contact: null,
+    details: null,
+    total_attendees: 0,
+    latest_attendees: [],
+    textsearch: null,
+    categories: [],
+    schedules: [],
+    approved_by: null,
+    rejected_by: null,
+    rejection_reason: null,
+    world: false,
+    place_id: null,
+    community_id: null,
+    scene_name: null,
+    coordinates: [0, 0],
+    ...overrides,
+  }
+}
+
+function createAdminRequest(
+  body: Record<string, unknown> = {},
+  eventId = EVENT_ID
+) {
+  return {
+    params: { event_id: eventId },
+    body,
+  } as any
+}
+
+function createBearerRequest(authorization?: string) {
+  return {
+    headers: authorization ? { authorization } : {},
+  } as any
+}
+
+async function expectRequestError(
+  promise: Promise<unknown>,
+  statusCode: number
+) {
+  await expect(promise).rejects.toMatchObject({ statusCode })
+}
+
+describe("events admin endpoints", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    mockEnvToken = VALID_TOKEN
+  })
+
+  describe("authentication", () => {
+    describe("when the authorization header is missing", () => {
+      let request: ReturnType<typeof createBearerRequest>
+
+      beforeEach(() => {
+        request = createBearerRequest()
+      })
+
+      it("should reject the request with a 401", async () => {
+        await jest.isolateModulesAsync(async () => {
+          const freshModule = await import("./middleware/adminBearer")
+          await expectRequestError(freshModule.assertAdminBearer(request), 401)
+        })
+      })
+    })
+
+    describe("when the authorization token is invalid", () => {
+      let request: ReturnType<typeof createBearerRequest>
+
+      beforeEach(() => {
+        request = createBearerRequest("Bearer invalid-token")
+      })
+
+      it("should reject the request with a 401", async () => {
+        await jest.isolateModulesAsync(async () => {
+          const freshModule = await import("./middleware/adminBearer")
+          await expectRequestError(freshModule.assertAdminBearer(request), 401)
+        })
+      })
+    })
+
+    describe("when EVENTS_ADMIN_AUTH_TOKEN is not configured", () => {
+      let request: ReturnType<typeof createBearerRequest>
+
+      beforeEach(() => {
+        mockEnvToken = ""
+        request = createBearerRequest(`Bearer ${VALID_TOKEN}`)
+      })
+
+      it("should reject the request with a 503", async () => {
+        await jest.isolateModulesAsync(async () => {
+          const freshModule = await import("./middleware/adminBearer")
+          await expectRequestError(freshModule.assertAdminBearer(request), 503)
+        })
+      })
+    })
+  })
+
+  describe("validation", () => {
+    describe("when event_id is not a UUID", () => {
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        request = createAdminRequest({}, "invalid-event-id")
+      })
+
+      it("should reject the request with a 400", async () => {
+        await expectRequestError(approveEvent(request), 400)
+      })
+    })
+
+    describe("when rejectEvent has no reason", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = createAdminRequest()
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+      })
+
+      it("should reject the request with a 400", async () => {
+        await expectRequestError(rejectEvent(request), 400)
+      })
+    })
+
+    describe("when rejectEvent has an empty reason", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = createAdminRequest({ reason: "   " })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+      })
+
+      it("should reject the request with a 400", async () => {
+        await expectRequestError(rejectEvent(request), 400)
+      })
+    })
+
+    describe("when patchEventAdmin receives an unsupported field", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = createAdminRequest({ unsupported: "field" })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+      })
+
+      it("should reject the request with a 400", async () => {
+        await expectRequestError(patchEventAdmin(request), 400)
+      })
+    })
+  })
+
+  describe("event lookup", () => {
+    describe("when the event does not exist", () => {
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        request = createAdminRequest()
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(null)
+      })
+
+      it("should reject the request with a 404", async () => {
+        await expectRequestError(approveEvent(request), 404)
+      })
+    })
+  })
+
+  describe("approveEvent", () => {
+    describe("when the event is pending", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = createAdminRequest({ actor: ACTOR })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+      })
+
+      it("should approve the event", async () => {
+        await approveEvent(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            approved: true,
+            approved_by: ACTOR,
+            rejected: false,
+            rejection_reason: null,
+          }),
+          { id: EVENT_ID }
+        )
+      })
+
+      it("should notify the approval", async () => {
+        await approveEvent(request)
+
+        expect(notifyApprovedEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: true })
+        )
+      })
+    })
+
+    describe("when the event is already approved", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent({ approved: true, approved_by: ACTOR })
+        request = createAdminRequest({ actor: ACTOR })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+      })
+
+      it("should return without writing or notifying again", async () => {
+        await approveEvent(request)
+
+        expect(EventModel.update).not.toHaveBeenCalled()
+        expect(notifyApprovedEvent).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe("getEventAdmin", () => {
+    describe("when the event exists", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = createAdminRequest()
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+      })
+
+      it("should return the event even when it is pending", async () => {
+        const response = await getEventAdmin(request)
+
+        expect(response).toEqual(expect.objectContaining({ id: EVENT_ID }))
+      })
+    })
+  })
+
+  describe("getEventAdminList", () => {
+    describe("when filtering pending events", () => {
+      let event: DeprecatedEventAttributes
+      let request: Record<string, unknown>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = {
+          query: { approved: "false", rejected: "false" },
+        }
+        ;(EventModel.getEvents as jest.Mock).mockResolvedValueOnce([event])
+      })
+
+      it("should query events with pending filters and allow pending rows", async () => {
+        await getEventAdminList(request as any)
+
+        expect(EventModel.getEvents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            allow_pending: true,
+            include_rejected: true,
+            approved: false,
+            rejected: false,
+          })
+        )
+      })
+    })
+
+    describe("when no rejection filter is provided", () => {
+      let event: DeprecatedEventAttributes
+      let request: Record<string, unknown>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        request = {
+          query: {},
+        }
+        ;(EventModel.getEvents as jest.Mock).mockResolvedValueOnce([event])
+      })
+
+      it("should include rejected rows in the admin query", async () => {
+        await getEventAdminList(request as any)
+
+        expect(EventModel.getEvents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            allow_pending: true,
+            include_rejected: true,
+            rejected: undefined,
+          })
+        )
+      })
+    })
+  })
+
+  describe("rejectEvent", () => {
+    describe("when a reason is provided", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent({ highlighted: true, trending: true })
+        request = createAdminRequest({
+          actor: ACTOR,
+          reason: "Suspicious external URL",
+        })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+      })
+
+      it("should reject the event and clear promotional flags", async () => {
+        await rejectEvent(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            approved: false,
+            rejected: true,
+            rejected_by: ACTOR,
+            rejection_reason: "Suspicious external URL",
+            highlighted: false,
+            trending: false,
+          }),
+          { id: EVENT_ID }
+        )
+      })
+
+      it("should notify the rejection", async () => {
+        await rejectEvent(request)
+
+        expect(notifyRejectedEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            rejected: true,
+            rejection_reason: "Suspicious external URL",
+          })
+        )
+      })
+    })
+  })
+
+  describe("unapproveEvent", () => {
+    describe("when the event is approved", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent({ approved: true, approved_by: ACTOR })
+        request = createAdminRequest()
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+      })
+
+      it("should clear the approval flag", async () => {
+        await unapproveEvent(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: false, approved_by: null }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+  })
+
+  describe("unrejectEvent", () => {
+    describe("when the event is rejected", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent({
+          rejected: true,
+          rejected_by: ACTOR,
+          rejection_reason: "Suspicious external URL",
+        })
+        request = createAdminRequest()
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+      })
+
+      it("should clear the rejection state", async () => {
+        await unrejectEvent(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            rejected: false,
+            rejected_by: null,
+            rejection_reason: null,
+          }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+  })
+
+  describe("patchEventAdmin", () => {
+    describe("when updating the name and description", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent({ approved: true })
+        request = createAdminRequest({
+          name: "Updated title",
+          description: "Updated description",
+        })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+        ;(
+          EventCategoryModel.validateCategories as jest.Mock
+        ).mockResolvedValueOnce(true)
+      })
+
+      it("should persist the patch", async () => {
+        await patchEventAdmin(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Updated title",
+            description: "Updated description",
+          }),
+          { id: EVENT_ID }
+        )
+      })
+
+      it("should notify the edit", async () => {
+        await patchEventAdmin(request)
+
+        expect(notifyEditedEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Updated title",
+            description: "Updated description",
+          })
+        )
+      })
+    })
+
+    describe("when the event has a custom URL", () => {
+      let event: DeprecatedEventAttributes
+      let request: ReturnType<typeof createAdminRequest>
+
+      beforeEach(() => {
+        event = createBaseEvent({
+          approved: true,
+          url: "https://community.example.com/custom-landing",
+        })
+        request = createAdminRequest({ name: "Renamed event" })
+        ;(EventModel.findOne as jest.Mock).mockResolvedValueOnce(event)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+        ;(
+          EventCategoryModel.validateCategories as jest.Mock
+        ).mockResolvedValueOnce(true)
+      })
+
+      it("should preserve the custom URL instead of regenerating it", async () => {
+        await patchEventAdmin(request)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "https://community.example.com/custom-landing",
+          }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+  })
+})

--- a/src/entities/Event/routes/admin.ts
+++ b/src/entities/Event/routes/admin.ts
@@ -1,0 +1,492 @@
+import { isInsideWorldLimits } from "@dcl/schemas/dist/dapps/world"
+import RequestError from "decentraland-gatsby/dist/entities/Route/error"
+import { createValidator } from "decentraland-gatsby/dist/entities/Route/validate"
+import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
+import API from "decentraland-gatsby/dist/utils/api/API"
+import Catalyst from "decentraland-gatsby/dist/utils/api/Catalyst"
+import Land from "decentraland-gatsby/dist/utils/api/Land"
+import Time from "decentraland-gatsby/dist/utils/date/Time"
+import env from "decentraland-gatsby/dist/utils/env"
+import { Request } from "express"
+import pick from "lodash/pick"
+
+import Places from "../../../api/Places"
+import EventCategoryModel from "../../EventCategory/model"
+import { DEFAULT_PROFILE_SETTINGS } from "../../ProfileSettings/types"
+import {
+  notifyApprovedEvent,
+  notifyEditedEvent,
+  notifyRejectedEvent,
+} from "../../Slack/utils"
+import EventModel from "../model"
+import { getEventParamsSchema, newEventSchema } from "../schemas"
+import {
+  DeprecatedEventAttributes,
+  EventAttributes,
+  EventListType,
+  GetEventParams,
+  MAX_EVENT_DURATION,
+  MAX_RECURRENT_PAST_ITERATIONS,
+  editEventAttributes,
+} from "../types"
+import {
+  calculateRecurrentProperties,
+  estimateRecurrentPastIterations,
+  eventTargetUrl,
+  validateImageUrl,
+} from "../utils"
+
+const DEFAULT_ADMIN_ACTOR = "jarvis-agent"
+const MAX_REJECTION_REASON_LENGTH = 500
+const MAX_ACTOR_LENGTH = 42
+
+const EVENTS_BASE_URL = env(
+  "EVENTS_BASE_URL",
+  "https://events.decentraland.org"
+)
+const JUMP_IN_SITE_URL = env(
+  "JUMP_IN_SITE_URL",
+  "https://decentraland.org/jump"
+)
+
+const validateParams = createValidator<GetEventParams>(
+  getEventParamsSchema as AjvObjectSchema
+)
+const validateUpdateEvent = createValidator<DeprecatedEventAttributes>(
+  newEventSchema as AjvObjectSchema
+)
+
+const adminPatchEventAttributes = editEventAttributes.filter(
+  (attribute) => attribute !== "rejected"
+)
+
+type AdminEventRequest = Request<
+  { event_id: string },
+  unknown,
+  Record<string, unknown>
+>
+type AdminEventListRequest = Request<
+  Record<string, never>,
+  unknown,
+  unknown,
+  Record<string, string | string[] | undefined>
+>
+
+function bodyAsRecord(req: AdminEventRequest): Record<string, unknown> {
+  return req.body && typeof req.body === "object" && !Array.isArray(req.body)
+    ? req.body
+    : {}
+}
+
+function getActor(body: Record<string, unknown>): string {
+  if (body.actor === undefined) {
+    return DEFAULT_ADMIN_ACTOR
+  }
+
+  if (typeof body.actor !== "string") {
+    throw new RequestError("actor must be a string", RequestError.BadRequest)
+  }
+
+  const actor = body.actor.trim()
+  if (!actor) {
+    throw new RequestError("actor cannot be empty", RequestError.BadRequest)
+  }
+
+  if (actor.length > MAX_ACTOR_LENGTH) {
+    throw new RequestError(
+      `actor must be ${MAX_ACTOR_LENGTH} characters or less`,
+      RequestError.BadRequest
+    )
+  }
+
+  return actor
+}
+
+function getRejectionReason(body: Record<string, unknown>): string {
+  if (typeof body.reason !== "string") {
+    throw new RequestError(
+      "rejection reason is required",
+      RequestError.BadRequest
+    )
+  }
+
+  const reason = body.reason.trim()
+  if (!reason) {
+    throw new RequestError(
+      "rejection reason cannot be empty",
+      RequestError.BadRequest
+    )
+  }
+
+  if (reason.length > MAX_REJECTION_REASON_LENGTH) {
+    throw new RequestError(
+      `rejection reason must be ${MAX_REJECTION_REASON_LENGTH} characters or less`,
+      RequestError.BadRequest
+    )
+  }
+
+  return reason
+}
+
+function toResponse(event: DeprecatedEventAttributes) {
+  return EventModel.toPublic(event, {
+    ...DEFAULT_PROFILE_SETTINGS,
+    user: event.user,
+  })
+}
+
+function parseBooleanQuery(
+  value: string | string[] | undefined,
+  field: string
+): boolean | undefined {
+  const rawValue = Array.isArray(value) ? value[0] : value
+  if (rawValue === undefined) {
+    return undefined
+  }
+
+  if (rawValue === "true" || rawValue === "1") {
+    return true
+  }
+
+  if (rawValue === "false" || rawValue === "0") {
+    return false
+  }
+
+  throw new RequestError(
+    `${field} must be true or false`,
+    RequestError.BadRequest
+  )
+}
+
+async function getAdminEvent(req: AdminEventRequest) {
+  const params = validateParams(req.params)
+  const event = EventModel.build(
+    await EventModel.findOne<EventAttributes>({ id: params.event_id })
+  )
+
+  if (!event) {
+    throw new RequestError(
+      `Not found event "${params.event_id}"`,
+      RequestError.NotFound
+    )
+  }
+
+  return event
+}
+
+async function persistEvent(
+  event: DeprecatedEventAttributes,
+  changes: Partial<DeprecatedEventAttributes>
+) {
+  await EventModel.update(changes, { id: event.id })
+  return {
+    ...event,
+    ...changes,
+  }
+}
+
+function buildApprovalChanges(
+  event: DeprecatedEventAttributes,
+  actor: string
+): Partial<DeprecatedEventAttributes> | null {
+  if (event.approved && !event.rejected && !event.rejection_reason) {
+    return null
+  }
+
+  return {
+    approved: true,
+    approved_by: actor,
+    rejected: false,
+    rejected_by: null,
+    rejection_reason: null,
+  }
+}
+
+function buildRejectionChanges(
+  event: DeprecatedEventAttributes,
+  actor: string,
+  reason: string
+): Partial<DeprecatedEventAttributes> | null {
+  if (event.rejected && event.rejection_reason === reason) {
+    return null
+  }
+
+  return {
+    approved: false,
+    rejected: true,
+    rejected_by: actor,
+    rejection_reason: reason,
+    highlighted: false,
+    trending: false,
+  }
+}
+
+export async function approveEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  const actor = getActor(bodyAsRecord(req))
+  const changes = buildApprovalChanges(event, actor)
+
+  if (!changes) {
+    return toResponse(event)
+  }
+
+  const updatedEvent = await persistEvent(event, changes)
+  await notifyApprovedEvent(updatedEvent)
+  return toResponse(updatedEvent)
+}
+
+export async function getEventAdmin(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  return toResponse(event)
+}
+
+export async function getEventAdminList(req: AdminEventListRequest) {
+  const approved = parseBooleanQuery(req.query.approved, "approved")
+  const rejected = parseBooleanQuery(req.query.rejected, "rejected")
+  const limit = req.query.limit
+    ? Math.min(Math.max(Number(req.query.limit), 0), 500)
+    : 100
+  const offset = req.query.offset ? Math.max(Number(req.query.offset), 0) : 0
+
+  if (!Number.isFinite(limit) || !Number.isFinite(offset)) {
+    throw new RequestError(
+      "limit and offset must be valid numbers",
+      RequestError.BadRequest
+    )
+  }
+
+  if (limit === 0) {
+    return []
+  }
+
+  const events = await EventModel.getEvents({
+    allow_pending: true,
+    include_rejected: true,
+    approved,
+    rejected,
+    limit,
+    offset,
+    list: EventListType.All,
+  })
+
+  return events.map((event) => toResponse(event))
+}
+
+export async function unapproveEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+
+  if (!event.approved && !event.approved_by) {
+    return toResponse(event)
+  }
+
+  const updatedEvent = await persistEvent(event, {
+    approved: false,
+    approved_by: null,
+  })
+
+  return toResponse(updatedEvent)
+}
+
+export async function rejectEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  const body = bodyAsRecord(req)
+  const actor = getActor(body)
+  const reason = getRejectionReason(body)
+  const changes = buildRejectionChanges(event, actor, reason)
+
+  if (!changes) {
+    return toResponse(event)
+  }
+
+  const updatedEvent = await persistEvent(event, changes)
+  if (!event.rejected) {
+    await notifyRejectedEvent(updatedEvent)
+  }
+  return toResponse(updatedEvent)
+}
+
+export async function unrejectEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+
+  if (!event.rejected && !event.rejected_by && !event.rejection_reason) {
+    return toResponse(event)
+  }
+
+  const updatedEvent = await persistEvent(event, {
+    rejected: false,
+    rejected_by: null,
+    rejection_reason: null,
+  })
+
+  return toResponse(updatedEvent)
+}
+
+function validateAdminPatchBody(body: Record<string, unknown>) {
+  const unsupportedFields = Object.keys(body).filter(
+    (field) =>
+      field !== "actor" &&
+      !adminPatchEventAttributes.includes(
+        field as (typeof adminPatchEventAttributes)[number]
+      )
+  )
+
+  if (unsupportedFields.length > 0) {
+    throw new RequestError(
+      `Unsupported admin event fields: ${unsupportedFields.join(", ")}`,
+      RequestError.BadRequest
+    )
+  }
+
+  const patchFields = Object.keys(body).filter((field) => field !== "actor")
+  if (patchFields.length === 0) {
+    throw new RequestError(
+      "At least one admin event field is required",
+      RequestError.BadRequest
+    )
+  }
+}
+
+export async function patchEventAdmin(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  const body = bodyAsRecord(req)
+  validateAdminPatchBody(body)
+
+  const updatedAttributes = {
+    ...pick(event, editEventAttributes),
+    url: event.url,
+    ...pick(body, adminPatchEventAttributes),
+  } as DeprecatedEventAttributes
+
+  if (
+    !updatedAttributes.url ||
+    updatedAttributes.url.startsWith(JUMP_IN_SITE_URL)
+  ) {
+    updatedAttributes.url = eventTargetUrl(updatedAttributes)
+  }
+
+  updatedAttributes.start_at = Time.date(updatedAttributes.start_at)
+  updatedAttributes.recurrent_until = Time.date(
+    updatedAttributes.recurrent_until
+  )
+
+  validateUpdateEvent({
+    ...updatedAttributes,
+    start_at: Time.date(updatedAttributes.start_at)?.toJSON(),
+    recurrent_until: Time.date(updatedAttributes.recurrent_until)?.toJSON(),
+  })
+
+  const touchesRecurrence = [
+    "start_at",
+    "recurrent",
+    "recurrent_frequency",
+    "recurrent_interval",
+    "recurrent_count",
+    "recurrent_until",
+  ].some((field) => body[field] !== undefined)
+  if (
+    touchesRecurrence &&
+    updatedAttributes.recurrent &&
+    estimateRecurrentPastIterations(updatedAttributes) >
+      MAX_RECURRENT_PAST_ITERATIONS
+  ) {
+    throw new RequestError(
+      `Recurrence rule expands to too many past occurrences from the start date; choose a later start date or a coarser frequency`,
+      RequestError.BadRequest,
+      { body: updatedAttributes }
+    )
+  }
+
+  if (body.image && body.image !== event.image) {
+    await validateImageUrl(body.image as string)
+  }
+
+  if (body.image_vertical && body.image_vertical !== event.image_vertical) {
+    await validateImageUrl(body.image_vertical as string)
+  }
+
+  if (
+    updatedAttributes.duration &&
+    updatedAttributes.duration > Math.max(event.duration, MAX_EVENT_DURATION)
+  ) {
+    throw new RequestError(
+      `Maximum allowed duration ${MAX_EVENT_DURATION / Time.Hour}Hrs`,
+      RequestError.BadRequest,
+      { body: updatedAttributes }
+    )
+  }
+
+  const userProfiles = await Catalyst.getInstance().getProfiles([event.user])
+  if (
+    userProfiles &&
+    userProfiles[0] &&
+    userProfiles[0].name &&
+    event.user_name !== userProfiles[0].name
+  ) {
+    updatedAttributes.user_name = userProfiles[0].name
+  }
+
+  const x = updatedAttributes.x
+  const y = updatedAttributes.y
+  if (!isInsideWorldLimits(x, y)) {
+    throw new RequestError(
+      `Event is outside the world limits`,
+      RequestError.BadRequest,
+      { body: updatedAttributes }
+    )
+  }
+
+  if (updatedAttributes.categories.length) {
+    const validation = await EventCategoryModel.validateCategories(
+      updatedAttributes.categories
+    )
+    if (!validation) {
+      throw new RequestError(
+        `Invalid category tag supplied`,
+        RequestError.BadRequest,
+        { body: event }
+      )
+    }
+  }
+
+  const tile = await API.catch(Land.getInstance().getTile([x, y]))
+  updatedAttributes.coordinates = [x, y]
+
+  if (!updatedAttributes.world) {
+    const place = await Places.get().getPlaceByPosition(`${x},${y}`)
+    updatedAttributes.estate_id = tile?.estateId || updatedAttributes.estate_id
+    updatedAttributes.estate_name = tile?.name || updatedAttributes.estate_name
+    updatedAttributes.scene_name = updatedAttributes.estate_name
+    updatedAttributes.place_id = place?.id || updatedAttributes.place_id
+  } else {
+    const world = await Places.get().getWorldByName(updatedAttributes.server!)
+    updatedAttributes.image =
+      updatedAttributes.image || `${EVENTS_BASE_URL}/images/event-default.jpg`
+    updatedAttributes.place_id = world?.id || updatedAttributes.place_id
+  }
+
+  Object.assign(
+    updatedAttributes,
+    calculateRecurrentProperties(updatedAttributes)
+  )
+
+  updatedAttributes.next_start_at = EventModel.selectNextStartAt(
+    updatedAttributes.duration,
+    updatedAttributes.start_at,
+    updatedAttributes.recurrent_dates
+  )
+
+  updatedAttributes.next_finish_at = new Date(
+    updatedAttributes.next_start_at.getTime() + updatedAttributes.duration
+  )
+
+  const updatedEvent = {
+    ...event,
+    ...updatedAttributes,
+  }
+
+  updatedAttributes.textsearch = EventModel.textsearch(updatedEvent)
+  const persistedEvent = await persistEvent(event, updatedAttributes)
+  await notifyEditedEvent(persistedEvent)
+
+  return toResponse(persistedEvent)
+}

--- a/src/entities/Event/routes/admin.ts
+++ b/src/entities/Event/routes/admin.ts
@@ -1,61 +1,35 @@
-import { isInsideWorldLimits } from "@dcl/schemas/dist/dapps/world"
 import RequestError from "decentraland-gatsby/dist/entities/Route/error"
 import { createValidator } from "decentraland-gatsby/dist/entities/Route/validate"
 import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
-import API from "decentraland-gatsby/dist/utils/api/API"
-import Catalyst from "decentraland-gatsby/dist/utils/api/Catalyst"
-import Land from "decentraland-gatsby/dist/utils/api/Land"
-import Time from "decentraland-gatsby/dist/utils/date/Time"
-import env from "decentraland-gatsby/dist/utils/env"
 import { Request } from "express"
-import pick from "lodash/pick"
 
-import Places from "../../../api/Places"
-import EventCategoryModel from "../../EventCategory/model"
 import { DEFAULT_PROFILE_SETTINGS } from "../../ProfileSettings/types"
-import {
-  notifyApprovedEvent,
-  notifyEditedEvent,
-  notifyRejectedEvent,
-} from "../../Slack/utils"
+import { notifyApprovedEvent, notifyRejectedEvent } from "../../Slack/utils"
 import EventModel from "../model"
-import { getEventParamsSchema, newEventSchema } from "../schemas"
+import { getEventParamsSchema } from "../schemas"
 import {
   DeprecatedEventAttributes,
   EventAttributes,
-  EventListType,
   GetEventParams,
   MAX_ADMIN_ACTOR_LENGTH,
-  MAX_EVENT_DURATION,
-  MAX_RECURRENT_PAST_ITERATIONS,
   MAX_REJECTION_REASON_LENGTH,
+  editAnyEventAttributes,
   editEventAttributes,
+  editOwnEventAttributes,
 } from "../types"
-import {
-  JUMP_IN_SITE_URL,
-  calculateRecurrentProperties,
-  estimateRecurrentPastIterations,
-  eventTargetUrl,
-  validateImageUrl,
-} from "../utils"
+import { updateEventWithOptions } from "./updateEvent"
 
 const DEFAULT_ADMIN_ACTOR = "jarvis-agent"
-
-const EVENTS_BASE_URL = env(
-  "EVENTS_BASE_URL",
-  "https://events.decentraland.org"
-)
 
 const validateParams = createValidator<GetEventParams>(
   getEventParamsSchema as AjvObjectSchema
 )
-const validateUpdateEvent = createValidator<DeprecatedEventAttributes>(
-  newEventSchema as AjvObjectSchema
-)
 
-const adminPatchEventAttributes = editEventAttributes.filter(
-  (attribute) => attribute !== "rejected"
-)
+const adminPatchEventAttributes = [
+  ...editEventAttributes.filter((attribute) => attribute !== "rejected"),
+  ...editOwnEventAttributes,
+  ...editAnyEventAttributes,
+]
 
 const STATE_ONLY_FIELDS = new Set(["actor", "approved", "rejected", "reason"])
 
@@ -64,13 +38,6 @@ type AdminEventRequest = Request<
   unknown,
   Record<string, unknown>
 >
-type AdminEventListRequest = Request<
-  Record<string, never>,
-  unknown,
-  unknown,
-  Record<string, string | string[] | undefined>
->
-
 function bodyAsRecord(req: AdminEventRequest): Record<string, unknown> {
   return req.body && typeof req.body === "object" && !Array.isArray(req.body)
     ? req.body
@@ -132,29 +99,6 @@ function toResponse(event: DeprecatedEventAttributes) {
     ...DEFAULT_PROFILE_SETTINGS,
     user: event.user,
   })
-}
-
-function parseBooleanQuery(
-  value: string | string[] | undefined,
-  field: string
-): boolean | undefined {
-  const rawValue = Array.isArray(value) ? value[0] : value
-  if (rawValue === undefined) {
-    return undefined
-  }
-
-  if (rawValue === "true" || rawValue === "1") {
-    return true
-  }
-
-  if (rawValue === "false" || rawValue === "0") {
-    return false
-  }
-
-  throw new RequestError(
-    `${field} must be true or false`,
-    RequestError.BadRequest
-  )
 }
 
 async function getAdminEvent(req: AdminEventRequest) {
@@ -234,43 +178,6 @@ async function approveEventByActor(
   const updatedEvent = await persistEvent(event, changes)
   await notifyApprovedEvent(updatedEvent)
   return toResponse(updatedEvent)
-}
-
-export async function getEventAdmin(req: AdminEventRequest) {
-  const event = await getAdminEvent(req)
-  return toResponse(event)
-}
-
-export async function getEventAdminList(req: AdminEventListRequest) {
-  const approved = parseBooleanQuery(req.query.approved, "approved")
-  const rejected = parseBooleanQuery(req.query.rejected, "rejected")
-  const limit = req.query.limit
-    ? Math.min(Math.max(Number(req.query.limit), 0), 500)
-    : 100
-  const offset = req.query.offset ? Math.max(Number(req.query.offset), 0) : 0
-
-  if (!Number.isFinite(limit) || !Number.isFinite(offset)) {
-    throw new RequestError(
-      "limit and offset must be valid numbers",
-      RequestError.BadRequest
-    )
-  }
-
-  if (limit === 0) {
-    return []
-  }
-
-  const events = await EventModel.getEvents({
-    allow_pending: true,
-    include_rejected: true,
-    approved,
-    rejected,
-    limit,
-    offset,
-    list: EventListType.All,
-  })
-
-  return events.map((event) => toResponse(event))
 }
 
 async function unapproveEventByActor(event: DeprecatedEventAttributes) {
@@ -433,143 +340,19 @@ export async function patchEventAdmin(req: AdminEventRequest) {
   }
 
   validateAdminPatchBody(body)
+  const actor = getActor(body)
 
-  const updatedAttributes = {
-    ...pick(event, editEventAttributes),
-    url: event.url,
-    ...pick(body, adminPatchEventAttributes),
-  } as DeprecatedEventAttributes
-
-  if (
-    !updatedAttributes.url ||
-    updatedAttributes.url.startsWith(JUMP_IN_SITE_URL)
-  ) {
-    updatedAttributes.url = eventTargetUrl(updatedAttributes)
-  }
-
-  updatedAttributes.start_at = Time.date(updatedAttributes.start_at)
-  updatedAttributes.recurrent_until = Time.date(
-    updatedAttributes.recurrent_until
-  )
-
-  validateUpdateEvent({
-    ...updatedAttributes,
-    start_at: Time.date(updatedAttributes.start_at)?.toJSON(),
-    recurrent_until: Time.date(updatedAttributes.recurrent_until)?.toJSON(),
-  })
-
-  const touchesRecurrence = [
-    "start_at",
-    "recurrent",
-    "recurrent_frequency",
-    "recurrent_interval",
-    "recurrent_count",
-    "recurrent_until",
-  ].some((field) => body[field] !== undefined)
-  if (
-    touchesRecurrence &&
-    updatedAttributes.recurrent &&
-    estimateRecurrentPastIterations(updatedAttributes) >
-      MAX_RECURRENT_PAST_ITERATIONS
-  ) {
-    throw new RequestError(
-      `Recurrence rule expands to too many past occurrences from the start date; choose a later start date or a coarser frequency`,
-      RequestError.BadRequest,
-      { body: updatedAttributes }
-    )
-  }
-
-  if (body.image && body.image !== event.image) {
-    await validateImageUrl(body.image as string)
-  }
-
-  if (body.image_vertical && body.image_vertical !== event.image_vertical) {
-    await validateImageUrl(body.image_vertical as string)
-  }
-
-  if (
-    updatedAttributes.duration &&
-    updatedAttributes.duration > Math.max(event.duration, MAX_EVENT_DURATION)
-  ) {
-    throw new RequestError(
-      `Maximum allowed duration ${MAX_EVENT_DURATION / Time.Hour}Hrs`,
-      RequestError.BadRequest,
-      { body: updatedAttributes }
-    )
-  }
-
-  const userProfiles = await Catalyst.getInstance().getProfiles([event.user])
-  if (
-    userProfiles &&
-    userProfiles[0] &&
-    userProfiles[0].name &&
-    event.user_name !== userProfiles[0].name
-  ) {
-    updatedAttributes.user_name = userProfiles[0].name
-  }
-
-  const x = updatedAttributes.x
-  const y = updatedAttributes.y
-  if (!isInsideWorldLimits(x, y)) {
-    throw new RequestError(
-      `Event is outside the world limits`,
-      RequestError.BadRequest,
-      { body: updatedAttributes }
-    )
-  }
-
-  if (updatedAttributes.categories.length) {
-    const validation = await EventCategoryModel.validateCategories(
-      updatedAttributes.categories
-    )
-    if (!validation) {
-      throw new RequestError(
-        `Invalid category tag supplied`,
-        RequestError.BadRequest,
-        { body: event }
-      )
+  return updateEventWithOptions(
+    req as unknown as Parameters<typeof updateEventWithOptions>[0],
+    {
+      admin: true,
+      actor,
+      event,
+      profile: {
+        ...DEFAULT_PROFILE_SETTINGS,
+        subscriptions: [],
+        user: event.user,
+      },
     }
-  }
-
-  const tile = await API.catch(Land.getInstance().getTile([x, y]))
-  updatedAttributes.coordinates = [x, y]
-
-  if (!updatedAttributes.world) {
-    const place = await Places.get().getPlaceByPosition(`${x},${y}`)
-    updatedAttributes.estate_id = tile?.estateId || updatedAttributes.estate_id
-    updatedAttributes.estate_name = tile?.name || updatedAttributes.estate_name
-    updatedAttributes.scene_name = updatedAttributes.estate_name
-    updatedAttributes.place_id = place?.id || updatedAttributes.place_id
-  } else {
-    const world = await Places.get().getWorldByName(updatedAttributes.server!)
-    updatedAttributes.image =
-      updatedAttributes.image || `${EVENTS_BASE_URL}/images/event-default.jpg`
-    updatedAttributes.place_id = world?.id || updatedAttributes.place_id
-  }
-
-  Object.assign(
-    updatedAttributes,
-    calculateRecurrentProperties(updatedAttributes)
   )
-
-  updatedAttributes.next_start_at = EventModel.selectNextStartAt(
-    updatedAttributes.duration,
-    updatedAttributes.start_at,
-    updatedAttributes.recurrent_dates
-  )
-
-  updatedAttributes.next_finish_at = new Date(
-    updatedAttributes.next_start_at.getTime() + updatedAttributes.duration
-  )
-
-  const updatedEvent = {
-    ...event,
-    ...updatedAttributes,
-  }
-
-  updatedAttributes.textsearch = EventModel.textsearch(updatedEvent)
-  const persistedEvent = await persistEvent(event, updatedAttributes)
-  await notifyEditedEvent(persistedEvent)
-
-  return toResponse(persistedEvent)
 }

--- a/src/entities/Event/routes/admin.ts
+++ b/src/entities/Event/routes/admin.ts
@@ -25,11 +25,14 @@ import {
   EventAttributes,
   EventListType,
   GetEventParams,
+  MAX_ADMIN_ACTOR_LENGTH,
   MAX_EVENT_DURATION,
   MAX_RECURRENT_PAST_ITERATIONS,
+  MAX_REJECTION_REASON_LENGTH,
   editEventAttributes,
 } from "../types"
 import {
+  JUMP_IN_SITE_URL,
   calculateRecurrentProperties,
   estimateRecurrentPastIterations,
   eventTargetUrl,
@@ -37,16 +40,10 @@ import {
 } from "../utils"
 
 const DEFAULT_ADMIN_ACTOR = "jarvis-agent"
-const MAX_REJECTION_REASON_LENGTH = 500
-const MAX_ACTOR_LENGTH = 42
 
 const EVENTS_BASE_URL = env(
   "EVENTS_BASE_URL",
   "https://events.decentraland.org"
-)
-const JUMP_IN_SITE_URL = env(
-  "JUMP_IN_SITE_URL",
-  "https://decentraland.org/jump"
 )
 
 const validateParams = createValidator<GetEventParams>(
@@ -60,13 +57,7 @@ const adminPatchEventAttributes = editEventAttributes.filter(
   (attribute) => attribute !== "rejected"
 )
 
-const STATE_ONLY_FIELDS = new Set([
-  "actor",
-  "approved",
-  "rejected",
-  "reason",
-  "rejection_reason",
-])
+const STATE_ONLY_FIELDS = new Set(["actor", "approved", "rejected", "reason"])
 
 type AdminEventRequest = Request<
   { event_id: string },
@@ -100,9 +91,9 @@ function getActor(body: Record<string, unknown>): string {
     throw new RequestError("actor cannot be empty", RequestError.BadRequest)
   }
 
-  if (actor.length > MAX_ACTOR_LENGTH) {
+  if (actor.length > MAX_ADMIN_ACTOR_LENGTH) {
     throw new RequestError(
-      `actor must be ${MAX_ACTOR_LENGTH} characters or less`,
+      `actor must be ${MAX_ADMIN_ACTOR_LENGTH} characters or less`,
       RequestError.BadRequest
     )
   }
@@ -348,7 +339,7 @@ function getBooleanField(
   return value
 }
 
-async function dispatchStateChange(
+async function applyStateChange(
   event: DeprecatedEventAttributes,
   body: Record<string, unknown>
 ) {
@@ -438,7 +429,7 @@ export async function patchEventAdmin(req: AdminEventRequest) {
   const body = bodyAsRecord(req)
 
   if (isStateOnlyBody(body)) {
-    return dispatchStateChange(event, body)
+    return applyStateChange(event, body)
   }
 
   validateAdminPatchBody(body)

--- a/src/entities/Event/routes/admin.ts
+++ b/src/entities/Event/routes/admin.ts
@@ -3,7 +3,11 @@ import { createValidator } from "decentraland-gatsby/dist/entities/Route/validat
 import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
 import { Request } from "express"
 
-import { DEFAULT_PROFILE_SETTINGS } from "../../ProfileSettings/types"
+import {
+  DEFAULT_PROFILE_SETTINGS,
+  ProfileSettingsAttributes,
+  ProfileSettingsSessionAttributes,
+} from "../../ProfileSettings/types"
 import { notifyApprovedEvent, notifyRejectedEvent } from "../../Slack/utils"
 import EventModel from "../model"
 import { getEventParamsSchema } from "../schemas"
@@ -12,21 +16,37 @@ import {
   EventAttributes,
   GetEventParams,
   MAX_ADMIN_ACTOR_LENGTH,
-  MAX_REJECTION_REASON_LENGTH,
   editAnyEventAttributes,
-  editEventAttributes,
+  editEventAttributesWithoutRejected,
   editOwnEventAttributes,
 } from "../types"
+import { validateRejectionReason } from "../utils"
 import { updateEventWithOptions } from "./updateEvent"
 
 const DEFAULT_ADMIN_ACTOR = "jarvis-agent"
+
+export function adminServiceProfile(user: string): ProfileSettingsAttributes {
+  return {
+    ...DEFAULT_PROFILE_SETTINGS,
+    user,
+  }
+}
+
+export function adminServiceSessionProfile(
+  user: string
+): ProfileSettingsSessionAttributes {
+  return {
+    ...adminServiceProfile(user),
+    subscriptions: [],
+  }
+}
 
 const validateParams = createValidator<GetEventParams>(
   getEventParamsSchema as AjvObjectSchema
 )
 
 const adminPatchEventAttributes = [
-  ...editEventAttributes.filter((attribute) => attribute !== "rejected"),
+  ...editEventAttributesWithoutRejected,
   ...editOwnEventAttributes,
   ...editAnyEventAttributes,
 ]
@@ -68,37 +88,8 @@ function getActor(body: Record<string, unknown>): string {
   return actor
 }
 
-function getRejectionReason(body: Record<string, unknown>): string {
-  if (typeof body.reason !== "string") {
-    throw new RequestError(
-      "rejection reason is required",
-      RequestError.BadRequest
-    )
-  }
-
-  const reason = body.reason.trim()
-  if (!reason) {
-    throw new RequestError(
-      "rejection reason cannot be empty",
-      RequestError.BadRequest
-    )
-  }
-
-  if (reason.length > MAX_REJECTION_REASON_LENGTH) {
-    throw new RequestError(
-      `rejection reason must be ${MAX_REJECTION_REASON_LENGTH} characters or less`,
-      RequestError.BadRequest
-    )
-  }
-
-  return reason
-}
-
 function toResponse(event: DeprecatedEventAttributes) {
-  return EventModel.toPublic(event, {
-    ...DEFAULT_PROFILE_SETTINGS,
-    user: event.user,
-  })
+  return EventModel.toPublic(event, adminServiceProfile(event.user))
 }
 
 async function getAdminEvent(req: AdminEventRequest) {
@@ -269,7 +260,7 @@ async function applyStateChange(
     return unapproveEventByActor(event)
   }
   if (rejected === true) {
-    const reason = getRejectionReason(body)
+    const reason = validateRejectionReason(body.reason, "rejection reason")
     return rejectEventByActor(event, actor, reason)
   }
   if (rejected === false) {
@@ -322,7 +313,7 @@ export async function rejectEvent(req: AdminEventRequest) {
   const event = await getAdminEvent(req)
   const body = bodyAsRecord(req)
   const actor = getActor(body)
-  const reason = getRejectionReason(body)
+  const reason = validateRejectionReason(body.reason, "rejection reason")
   return rejectEventByActor(event, actor, reason)
 }
 
@@ -348,11 +339,7 @@ export async function patchEventAdmin(req: AdminEventRequest) {
       admin: true,
       actor,
       event,
-      profile: {
-        ...DEFAULT_PROFILE_SETTINGS,
-        subscriptions: [],
-        user: event.user,
-      },
+      profile: adminServiceSessionProfile(event.user),
     }
   )
 }

--- a/src/entities/Event/routes/admin.ts
+++ b/src/entities/Event/routes/admin.ts
@@ -60,6 +60,14 @@ const adminPatchEventAttributes = editEventAttributes.filter(
   (attribute) => attribute !== "rejected"
 )
 
+const STATE_ONLY_FIELDS = new Set([
+  "actor",
+  "approved",
+  "rejected",
+  "reason",
+  "rejection_reason",
+])
+
 type AdminEventRequest = Request<
   { event_id: string },
   unknown,
@@ -213,6 +221,7 @@ function buildRejectionChanges(
 
   return {
     approved: false,
+    approved_by: null,
     rejected: true,
     rejected_by: actor,
     rejection_reason: reason,
@@ -221,9 +230,10 @@ function buildRejectionChanges(
   }
 }
 
-export async function approveEvent(req: AdminEventRequest) {
-  const event = await getAdminEvent(req)
-  const actor = getActor(bodyAsRecord(req))
+async function approveEventByActor(
+  event: DeprecatedEventAttributes,
+  actor: string
+) {
   const changes = buildApprovalChanges(event, actor)
 
   if (!changes) {
@@ -272,9 +282,7 @@ export async function getEventAdminList(req: AdminEventListRequest) {
   return events.map((event) => toResponse(event))
 }
 
-export async function unapproveEvent(req: AdminEventRequest) {
-  const event = await getAdminEvent(req)
-
+async function unapproveEventByActor(event: DeprecatedEventAttributes) {
   if (!event.approved && !event.approved_by) {
     return toResponse(event)
   }
@@ -287,11 +295,11 @@ export async function unapproveEvent(req: AdminEventRequest) {
   return toResponse(updatedEvent)
 }
 
-export async function rejectEvent(req: AdminEventRequest) {
-  const event = await getAdminEvent(req)
-  const body = bodyAsRecord(req)
-  const actor = getActor(body)
-  const reason = getRejectionReason(body)
+async function rejectEventByActor(
+  event: DeprecatedEventAttributes,
+  actor: string,
+  reason: string
+) {
   const changes = buildRejectionChanges(event, actor, reason)
 
   if (!changes) {
@@ -305,9 +313,7 @@ export async function rejectEvent(req: AdminEventRequest) {
   return toResponse(updatedEvent)
 }
 
-export async function unrejectEvent(req: AdminEventRequest) {
-  const event = await getAdminEvent(req)
-
+async function unrejectEventByActor(event: DeprecatedEventAttributes) {
   if (!event.rejected && !event.rejected_by && !event.rejection_reason) {
     return toResponse(event)
   }
@@ -319,6 +325,63 @@ export async function unrejectEvent(req: AdminEventRequest) {
   })
 
   return toResponse(updatedEvent)
+}
+
+function isStateOnlyBody(body: Record<string, unknown>): boolean {
+  const fields = Object.keys(body)
+  if (fields.length === 0) return false
+  return fields.every((field) => STATE_ONLY_FIELDS.has(field))
+}
+
+function getBooleanField(
+  body: Record<string, unknown>,
+  field: string
+): boolean | undefined {
+  if (!(field in body)) return undefined
+  const value = body[field]
+  if (typeof value !== "boolean") {
+    throw new RequestError(
+      `${field} must be a boolean`,
+      RequestError.BadRequest
+    )
+  }
+  return value
+}
+
+async function dispatchStateChange(
+  event: DeprecatedEventAttributes,
+  body: Record<string, unknown>
+) {
+  const approved = getBooleanField(body, "approved")
+  const rejected = getBooleanField(body, "rejected")
+
+  if (approved !== undefined && rejected !== undefined) {
+    throw new RequestError(
+      "approved and rejected cannot be set in the same request",
+      RequestError.BadRequest
+    )
+  }
+
+  const actor = getActor(body)
+
+  if (approved === true) {
+    return approveEventByActor(event, actor)
+  }
+  if (approved === false) {
+    return unapproveEventByActor(event)
+  }
+  if (rejected === true) {
+    const reason = getRejectionReason(body)
+    return rejectEventByActor(event, actor, reason)
+  }
+  if (rejected === false) {
+    return unrejectEventByActor(event)
+  }
+
+  throw new RequestError(
+    "approved or rejected field is required",
+    RequestError.BadRequest
+  )
 }
 
 function validateAdminPatchBody(body: Record<string, unknown>) {
@@ -346,9 +409,38 @@ function validateAdminPatchBody(body: Record<string, unknown>) {
   }
 }
 
+export async function approveEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  const actor = getActor(bodyAsRecord(req))
+  return approveEventByActor(event, actor)
+}
+
+export async function unapproveEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  return unapproveEventByActor(event)
+}
+
+export async function rejectEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  const body = bodyAsRecord(req)
+  const actor = getActor(body)
+  const reason = getRejectionReason(body)
+  return rejectEventByActor(event, actor, reason)
+}
+
+export async function unrejectEvent(req: AdminEventRequest) {
+  const event = await getAdminEvent(req)
+  return unrejectEventByActor(event)
+}
+
 export async function patchEventAdmin(req: AdminEventRequest) {
   const event = await getAdminEvent(req)
   const body = bodyAsRecord(req)
+
+  if (isStateOnlyBody(body)) {
+    return dispatchStateChange(event, body)
+  }
+
   validateAdminPatchBody(body)
 
   const updatedAttributes = {

--- a/src/entities/Event/routes/createEvent.ts
+++ b/src/entities/Event/routes/createEvent.ts
@@ -210,6 +210,7 @@ export async function createEvent(req: WithAuthProfile<WithAuth>) {
     scene_name: estate_name,
     approved: false,
     rejected: false,
+    rejection_reason: null,
     highlighted: false,
     trending: false,
     total_attendees: 0,

--- a/src/entities/Event/routes/getEvent.ts
+++ b/src/entities/Event/routes/getEvent.ts
@@ -19,9 +19,19 @@ import { EventAttributes, GetEventParams } from "../types"
 export const validateGetEventParams =
   createValidator<GetEventParams>(getEventParamsSchema)
 
-export const getEvent = oncePerRequest(async (req: WithAuth) => {
+export type GetEventOptions = {
+  includePending?: boolean
+  includeRejected?: boolean
+  profile?: ProfileSettingsAttributes
+  profileForEvent?: (event: EventAttributes) => ProfileSettingsAttributes
+}
+
+export async function getEventWithOptions(
+  req: WithAuth,
+  options: GetEventOptions = {}
+) {
   const user = req.auth
-  const profile = await getAuthProfileSettings(req)
+  let profile = options.profile
   const params = validateGetEventParams(req.params)
 
   if (!isUUID(params.event_id)) {
@@ -42,7 +52,17 @@ export const getEvent = oncePerRequest(async (req: WithAuth) => {
     )
   }
 
-  if (!event.approved) {
+  if (options.profileForEvent) {
+    profile = options.profileForEvent(event)
+  } else if (!profile) {
+    profile = await getAuthProfileSettings(req)
+  }
+
+  if ((!event.approved && !options.includePending) || event.rejected) {
+    if (event.rejected && options.includeRejected) {
+      return EventModel.toPublic(event, profile)
+    }
+
     if (!user) {
       throw new RequestError(
         `Not found event "${params.event_id}"`,
@@ -69,6 +89,10 @@ export const getEvent = oncePerRequest(async (req: WithAuth) => {
   }
 
   return { ...EventModel.toPublic(event, profile), attending }
+}
+
+export const getEvent = oncePerRequest(async (req: WithAuth) => {
+  return getEventWithOptions(req)
 })
 
 function canReadEvent(

--- a/src/entities/Event/routes/getEventList.ts
+++ b/src/entities/Event/routes/getEventList.ts
@@ -117,7 +117,14 @@ export function addConnectedUsersToEvents<
 }
 
 const validate = createValidator<EventListParams>(getEventListQuery)
-export async function getEventList(req: WithAuth) {
+export type GetEventListOptions = {
+  admin?: boolean
+}
+
+export async function getEventList(
+  req: WithAuth,
+  routeOptions: GetEventListOptions = {}
+) {
   const profile = await getAuthProfileSettings(req)
 
   // Handle body format: { placeIds: [...], communityId?: string }
@@ -135,16 +142,23 @@ export async function getEventList(req: WithAuth) {
   })
   const options: EventListOptions = {
     user: profile.user,
-    allow_pending:
-      isAdmin(profile.user) ||
-      canEditAnyEvent(profile) ||
-      canApproveAnyEvent(profile),
+    allow_pending: routeOptions.admin
+      ? true
+      : isAdmin(profile.user) ||
+        canEditAnyEvent(profile) ||
+        canApproveAnyEvent(profile),
+    include_rejected: routeOptions.admin ? true : undefined,
     offset: query.offset ? Math.max(Number(query.offset), 0) : 0,
     limit: query.limit
       ? Math.min(Math.max(Number(req.query["limit"]), 0), 500)
       : 500,
     list: query.list || EventListType.Active,
     order: query.order,
+  }
+
+  if (routeOptions.admin) {
+    options.approved = bool(query.approved) ?? undefined
+    options.rejected = bool(query.rejected) ?? undefined
   }
 
   if (options.limit === 0) {

--- a/src/entities/Event/routes/index.ts
+++ b/src/entities/Event/routes/index.ts
@@ -6,14 +6,13 @@ import { withCors } from "decentraland-gatsby/dist/entities/Route/middleware"
 import routes from "decentraland-gatsby/dist/entities/Route/routes"
 import { Request } from "express"
 
-import { patchEventAdmin } from "./admin"
+import { adminServiceProfile, patchEventAdmin } from "./admin"
 import { createEvent } from "./createEvent"
 import { getAttendingEventList } from "./getAttendingEventList"
 import { getEvent, getEventWithOptions } from "./getEvent"
 import { getEventList } from "./getEventList"
 import { WithAdminBearer, adminBearer } from "./middleware/adminBearer"
 import { updateEvent } from "./updateEvent"
-import { DEFAULT_PROFILE_SETTINGS } from "../../ProfileSettings/types"
 
 type MaybeAdminRequest = Request & WithAdminBearer & { auth?: string }
 
@@ -30,10 +29,7 @@ async function getEventRoute(req: MaybeAdminRequest) {
       {
         includePending: true,
         includeRejected: true,
-        profileForEvent: (event) => ({
-          ...DEFAULT_PROFILE_SETTINGS,
-          user: event.user,
-        }),
+        profileForEvent: (event) => adminServiceProfile(event.user),
       }
     )
   }

--- a/src/entities/Event/routes/index.ts
+++ b/src/entities/Event/routes/index.ts
@@ -1,9 +1,9 @@
 import { auth } from "decentraland-gatsby/dist/entities/Auth/middleware"
 import { withAuthProfile } from "decentraland-gatsby/dist/entities/Profile/middleware"
+import RequestError from "decentraland-gatsby/dist/entities/Route/error"
 import handle from "decentraland-gatsby/dist/entities/Route/handle"
 import { withCors } from "decentraland-gatsby/dist/entities/Route/middleware"
 import routes from "decentraland-gatsby/dist/entities/Route/routes"
-import env from "decentraland-gatsby/dist/utils/env"
 import { Request } from "express"
 
 import { getEventAdmin, getEventAdminList, patchEventAdmin } from "./admin"
@@ -11,39 +11,34 @@ import { createEvent } from "./createEvent"
 import { getAttendingEventList } from "./getAttendingEventList"
 import { getEvent } from "./getEvent"
 import { getEventList } from "./getEventList"
-import {
-  adminBearerOrAuth,
-  adminBearerOrOptionalAuth,
-} from "./middleware/adminBearer"
+import { WithAdminBearer, adminBearer } from "./middleware/adminBearer"
 import { updateEvent } from "./updateEvent"
 
-export const JUMP_IN_SITE_URL = env(
-  "JUMP_IN_SITE_URL",
-  "https://decentraland.org/jump"
-)
+type MaybeAdminRequest = Request & WithAdminBearer & { auth?: string }
 
-type AdminFlaggedRequest = Request & { isAdminBearer?: boolean }
-
-function isAdminBearer(req: Request): boolean {
-  return (req as AdminFlaggedRequest).isAdminBearer === true
+function requireAuthOrAdmin(req: MaybeAdminRequest): void {
+  if (!req.auth && !req.isAdminBearer) {
+    throw new RequestError("Unauthorized", RequestError.Unauthorized)
+  }
 }
 
-async function dispatchGetEvent(req: Request) {
-  if (isAdminBearer(req)) {
+async function getEventRoute(req: MaybeAdminRequest) {
+  if (req.isAdminBearer) {
     return getEventAdmin(req as Parameters<typeof getEventAdmin>[0])
   }
   return getEvent(req as Parameters<typeof getEvent>[0])
 }
 
-async function dispatchGetEventList(req: Request) {
-  if (isAdminBearer(req)) {
+async function getEventListRoute(req: MaybeAdminRequest) {
+  if (req.isAdminBearer) {
     return getEventAdminList(req as Parameters<typeof getEventAdminList>[0])
   }
   return getEventList(req as Parameters<typeof getEventList>[0])
 }
 
-async function dispatchPatchEvent(req: Request) {
-  if (isAdminBearer(req)) {
+async function patchEventRoute(req: MaybeAdminRequest) {
+  requireAuthOrAdmin(req)
+  if (req.isAdminBearer) {
     return patchEventAdmin(req as Parameters<typeof patchEventAdmin>[0])
   }
   return updateEvent(req as Parameters<typeof updateEvent>[0])
@@ -51,19 +46,22 @@ async function dispatchPatchEvent(req: Request) {
 
 export default routes((router) => {
   const withAuth = auth()
+  const withOptionalAuth = auth({ optional: true })
   const withPublicAccess = withCors({ cors: "*" })
   router.get(
     "/events",
     withPublicAccess,
-    adminBearerOrOptionalAuth(),
-    handle(dispatchGetEventList as any)
+    withOptionalAuth,
+    adminBearer,
+    handle(getEventListRoute as any)
   )
   router.post("/events", withAuth, withAuthProfile(), handle(createEvent))
   router.post(
     "/events/search",
     withPublicAccess,
-    adminBearerOrOptionalAuth(),
-    handle(dispatchGetEventList as any)
+    withOptionalAuth,
+    adminBearer,
+    handle(getEventListRoute as any)
   )
   router.get(
     "/events/attending",
@@ -74,12 +72,14 @@ export default routes((router) => {
   router.get(
     "/events/:event_id",
     withPublicAccess,
-    adminBearerOrOptionalAuth(),
-    handle(dispatchGetEvent as any)
+    withOptionalAuth,
+    adminBearer,
+    handle(getEventRoute as any)
   )
   router.patch(
     "/events/:event_id",
-    adminBearerOrAuth(),
-    handle(dispatchPatchEvent as any)
+    withOptionalAuth,
+    adminBearer,
+    handle(patchEventRoute as any)
   )
 })

--- a/src/entities/Event/routes/index.ts
+++ b/src/entities/Event/routes/index.ts
@@ -6,13 +6,14 @@ import { withCors } from "decentraland-gatsby/dist/entities/Route/middleware"
 import routes from "decentraland-gatsby/dist/entities/Route/routes"
 import { Request } from "express"
 
-import { getEventAdmin, getEventAdminList, patchEventAdmin } from "./admin"
+import { patchEventAdmin } from "./admin"
 import { createEvent } from "./createEvent"
 import { getAttendingEventList } from "./getAttendingEventList"
-import { getEvent } from "./getEvent"
+import { getEvent, getEventWithOptions } from "./getEvent"
 import { getEventList } from "./getEventList"
 import { WithAdminBearer, adminBearer } from "./middleware/adminBearer"
 import { updateEvent } from "./updateEvent"
+import { DEFAULT_PROFILE_SETTINGS } from "../../ProfileSettings/types"
 
 type MaybeAdminRequest = Request & WithAdminBearer & { auth?: string }
 
@@ -24,14 +25,26 @@ function requireAuthOrAdmin(req: MaybeAdminRequest): void {
 
 async function getEventRoute(req: MaybeAdminRequest) {
   if (req.isAdminBearer) {
-    return getEventAdmin(req as Parameters<typeof getEventAdmin>[0])
+    return getEventWithOptions(
+      req as unknown as Parameters<typeof getEventWithOptions>[0],
+      {
+        includePending: true,
+        includeRejected: true,
+        profileForEvent: (event) => ({
+          ...DEFAULT_PROFILE_SETTINGS,
+          user: event.user,
+        }),
+      }
+    )
   }
   return getEvent(req as Parameters<typeof getEvent>[0])
 }
 
 async function getEventListRoute(req: MaybeAdminRequest) {
   if (req.isAdminBearer) {
-    return getEventAdminList(req as Parameters<typeof getEventAdminList>[0])
+    return getEventList(req as Parameters<typeof getEventList>[0], {
+      admin: true,
+    })
   }
   return getEventList(req as Parameters<typeof getEventList>[0])
 }

--- a/src/entities/Event/routes/index.ts
+++ b/src/entities/Event/routes/index.ts
@@ -4,21 +4,17 @@ import handle from "decentraland-gatsby/dist/entities/Route/handle"
 import { withCors } from "decentraland-gatsby/dist/entities/Route/middleware"
 import routes from "decentraland-gatsby/dist/entities/Route/routes"
 import env from "decentraland-gatsby/dist/utils/env"
+import { Request } from "express"
 
-import {
-  approveEvent,
-  getEventAdmin,
-  getEventAdminList,
-  patchEventAdmin,
-  rejectEvent,
-  unapproveEvent,
-  unrejectEvent,
-} from "./admin"
+import { getEventAdmin, getEventAdminList, patchEventAdmin } from "./admin"
 import { createEvent } from "./createEvent"
 import { getAttendingEventList } from "./getAttendingEventList"
 import { getEvent } from "./getEvent"
 import { getEventList } from "./getEventList"
-import { adminBearer } from "./middleware/adminBearer"
+import {
+  adminBearerOrAuth,
+  adminBearerOrOptionalAuth,
+} from "./middleware/adminBearer"
 import { updateEvent } from "./updateEvent"
 
 export const JUMP_IN_SITE_URL = env(
@@ -26,22 +22,48 @@ export const JUMP_IN_SITE_URL = env(
   "https://decentraland.org/jump"
 )
 
+type AdminFlaggedRequest = Request & { isAdminBearer?: boolean }
+
+function isAdminBearer(req: Request): boolean {
+  return (req as AdminFlaggedRequest).isAdminBearer === true
+}
+
+async function dispatchGetEvent(req: Request) {
+  if (isAdminBearer(req)) {
+    return getEventAdmin(req as Parameters<typeof getEventAdmin>[0])
+  }
+  return getEvent(req as Parameters<typeof getEvent>[0])
+}
+
+async function dispatchGetEventList(req: Request) {
+  if (isAdminBearer(req)) {
+    return getEventAdminList(req as Parameters<typeof getEventAdminList>[0])
+  }
+  return getEventList(req as Parameters<typeof getEventList>[0])
+}
+
+async function dispatchPatchEvent(req: Request) {
+  if (isAdminBearer(req)) {
+    return patchEventAdmin(req as Parameters<typeof patchEventAdmin>[0])
+  }
+  return updateEvent(req as Parameters<typeof updateEvent>[0])
+}
+
 export default routes((router) => {
   const withAuth = auth()
-  const withOptionalAuth = auth({ optional: true })
   const withPublicAccess = withCors({ cors: "*" })
   router.get(
     "/events",
     withPublicAccess,
-    withOptionalAuth,
-    handle(getEventList as any)
+    adminBearerOrOptionalAuth(),
+    handle(dispatchGetEventList as any)
   )
   router.post("/events", withAuth, withAuthProfile(), handle(createEvent))
   router.post(
     "/events/search",
     withPublicAccess,
-    withOptionalAuth,
-    handle(getEventList as any)
+    adminBearerOrOptionalAuth(),
+    handle(dispatchGetEventList as any)
   )
   router.get(
     "/events/attending",
@@ -49,42 +71,15 @@ export default routes((router) => {
     withAuth,
     handle(getAttendingEventList)
   )
-  router.get("/events/admin", adminBearer, handle(getEventAdminList as any))
-  router.get(
-    "/events/:event_id/admin",
-    adminBearer,
-    handle(getEventAdmin as any)
-  )
   router.get(
     "/events/:event_id",
     withPublicAccess,
-    withOptionalAuth,
-    handle(getEvent)
-  )
-  router.put(
-    "/events/:event_id/approved",
-    adminBearer,
-    handle(approveEvent as any)
-  )
-  router.delete(
-    "/events/:event_id/approved",
-    adminBearer,
-    handle(unapproveEvent as any)
-  )
-  router.put(
-    "/events/:event_id/rejected",
-    adminBearer,
-    handle(rejectEvent as any)
-  )
-  router.delete(
-    "/events/:event_id/rejected",
-    adminBearer,
-    handle(unrejectEvent as any)
+    adminBearerOrOptionalAuth(),
+    handle(dispatchGetEvent as any)
   )
   router.patch(
-    "/events/:event_id/admin",
-    adminBearer,
-    handle(patchEventAdmin as any)
+    "/events/:event_id",
+    adminBearerOrAuth(),
+    handle(dispatchPatchEvent as any)
   )
-  router.patch("/events/:event_id", withAuth, handle(updateEvent))
 })

--- a/src/entities/Event/routes/index.ts
+++ b/src/entities/Event/routes/index.ts
@@ -5,10 +5,20 @@ import { withCors } from "decentraland-gatsby/dist/entities/Route/middleware"
 import routes from "decentraland-gatsby/dist/entities/Route/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
+import {
+  approveEvent,
+  getEventAdmin,
+  getEventAdminList,
+  patchEventAdmin,
+  rejectEvent,
+  unapproveEvent,
+  unrejectEvent,
+} from "./admin"
 import { createEvent } from "./createEvent"
 import { getAttendingEventList } from "./getAttendingEventList"
 import { getEvent } from "./getEvent"
 import { getEventList } from "./getEventList"
+import { adminBearer } from "./middleware/adminBearer"
 import { updateEvent } from "./updateEvent"
 
 export const JUMP_IN_SITE_URL = env(
@@ -39,11 +49,42 @@ export default routes((router) => {
     withAuth,
     handle(getAttendingEventList)
   )
+  router.get("/events/admin", adminBearer, handle(getEventAdminList as any))
+  router.get(
+    "/events/:event_id/admin",
+    adminBearer,
+    handle(getEventAdmin as any)
+  )
   router.get(
     "/events/:event_id",
     withPublicAccess,
     withOptionalAuth,
     handle(getEvent)
+  )
+  router.put(
+    "/events/:event_id/approved",
+    adminBearer,
+    handle(approveEvent as any)
+  )
+  router.delete(
+    "/events/:event_id/approved",
+    adminBearer,
+    handle(unapproveEvent as any)
+  )
+  router.put(
+    "/events/:event_id/rejected",
+    adminBearer,
+    handle(rejectEvent as any)
+  )
+  router.delete(
+    "/events/:event_id/rejected",
+    adminBearer,
+    handle(unrejectEvent as any)
+  )
+  router.patch(
+    "/events/:event_id/admin",
+    adminBearer,
+    handle(patchEventAdmin as any)
   )
   router.patch("/events/:event_id", withAuth, handle(updateEvent))
 })

--- a/src/entities/Event/routes/middleware/adminBearer.ts
+++ b/src/entities/Event/routes/middleware/adminBearer.ts
@@ -1,26 +1,18 @@
 import { createHash, timingSafeEqual } from "crypto"
 
-import { auth } from "decentraland-gatsby/dist/entities/Auth/middleware"
-import { withAuthProfile } from "decentraland-gatsby/dist/entities/Profile/middleware"
 import RequestError from "decentraland-gatsby/dist/entities/Route/error"
-import middleware from "decentraland-gatsby/dist/entities/Route/handle/middleware"
 import env from "decentraland-gatsby/dist/utils/env"
 import { NextFunction, Request, Response } from "express"
 
 const ADMIN_TOKEN = env("EVENTS_ADMIN_AUTH_TOKEN", "")
 const BEARER_PREFIX = "Bearer "
 
+export type WithAdminBearer = { isAdminBearer?: boolean }
+
 function safeCompare(value: string, expected: string): boolean {
   const valueHash = createHash("sha256").update(value).digest()
   const expectedHash = createHash("sha256").update(expected).digest()
   return timingSafeEqual(valueHash, expectedHash)
-}
-
-function hasBearerAuthorization(req: Pick<Request, "headers">): boolean {
-  const authorization = req.headers.authorization
-  return (
-    typeof authorization === "string" && authorization.startsWith(BEARER_PREFIX)
-  )
 }
 
 export async function assertAdminBearer(req: Pick<Request, "headers">) {
@@ -45,45 +37,23 @@ export async function assertAdminBearer(req: Pick<Request, "headers">) {
   }
 }
 
-export const adminBearer = middleware(assertAdminBearer)
+export function adminBearer(req: Request, _res: Response, next: NextFunction) {
+  if ((req as Request & { auth?: string }).auth) {
+    return next()
+  }
 
-export function adminBearerOrAuth(options?: { withProfile?: boolean }) {
-  const userAuth = auth()
-  const userProfile = options?.withProfile ? withAuthProfile() : null
+  const authorization = req.headers.authorization
+  if (
+    typeof authorization !== "string" ||
+    !authorization.startsWith(BEARER_PREFIX)
+  ) {
+    return next()
+  }
 
-  return (req: Request, res: Response, next: NextFunction) => {
-    if (hasBearerAuthorization(req)) {
-      assertAdminBearer(req)
-        .then(() => {
-          ;(req as Request & { isAdminBearer?: boolean }).isAdminBearer = true
-          next()
-        })
-        .catch(next)
-      return
-    }
-
-    userAuth(req, res, (err?: unknown) => {
-      if (err) return next(err as Error)
-      if (!userProfile) return next()
-      userProfile(req, res, next)
+  assertAdminBearer(req)
+    .then(() => {
+      ;(req as Request & WithAdminBearer).isAdminBearer = true
+      next()
     })
-  }
-}
-
-export function adminBearerOrOptionalAuth() {
-  const userAuth = auth({ optional: true })
-
-  return (req: Request, res: Response, next: NextFunction) => {
-    if (hasBearerAuthorization(req)) {
-      assertAdminBearer(req)
-        .then(() => {
-          ;(req as Request & { isAdminBearer?: boolean }).isAdminBearer = true
-          next()
-        })
-        .catch(next)
-      return
-    }
-
-    userAuth(req, res, next)
-  }
+    .catch(next)
 }

--- a/src/entities/Event/routes/middleware/adminBearer.ts
+++ b/src/entities/Event/routes/middleware/adminBearer.ts
@@ -37,7 +37,11 @@ export async function assertAdminBearer(req: Pick<Request, "headers">) {
   }
 }
 
-export function adminBearer(req: Request, _res: Response, next: NextFunction) {
+export async function adminBearer(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) {
   if ((req as Request & { auth?: string }).auth) {
     return next()
   }
@@ -50,10 +54,11 @@ export function adminBearer(req: Request, _res: Response, next: NextFunction) {
     return next()
   }
 
-  assertAdminBearer(req)
-    .then(() => {
-      ;(req as Request & WithAdminBearer).isAdminBearer = true
-      next()
-    })
-    .catch(next)
+  try {
+    await assertAdminBearer(req)
+    ;(req as Request & WithAdminBearer).isAdminBearer = true
+    next()
+  } catch (err) {
+    next(err)
+  }
 }

--- a/src/entities/Event/routes/middleware/adminBearer.ts
+++ b/src/entities/Event/routes/middleware/adminBearer.ts
@@ -1,0 +1,39 @@
+import { createHash, timingSafeEqual } from "crypto"
+
+import RequestError from "decentraland-gatsby/dist/entities/Route/error"
+import middleware from "decentraland-gatsby/dist/entities/Route/handle/middleware"
+import env from "decentraland-gatsby/dist/utils/env"
+import { Request } from "express"
+
+const ADMIN_TOKEN = env("EVENTS_ADMIN_AUTH_TOKEN", "")
+const BEARER_PREFIX = "Bearer "
+
+function safeCompare(value: string, expected: string): boolean {
+  const valueHash = createHash("sha256").update(value).digest()
+  const expectedHash = createHash("sha256").update(expected).digest()
+  return timingSafeEqual(valueHash, expectedHash)
+}
+
+export async function assertAdminBearer(req: Pick<Request, "headers">) {
+  if (!ADMIN_TOKEN) {
+    throw new RequestError(
+      "EVENTS_ADMIN_AUTH_TOKEN is not configured; events admin endpoints are disabled",
+      RequestError.ServiceUnavailable
+    )
+  }
+
+  const authorization = req.headers.authorization
+  if (
+    typeof authorization !== "string" ||
+    !authorization.startsWith(BEARER_PREFIX)
+  ) {
+    throw new RequestError("Unauthorized", RequestError.Unauthorized)
+  }
+
+  const token = authorization.slice(BEARER_PREFIX.length)
+  if (!safeCompare(token, ADMIN_TOKEN)) {
+    throw new RequestError("Unauthorized", RequestError.Unauthorized)
+  }
+}
+
+export const adminBearer = middleware(assertAdminBearer)

--- a/src/entities/Event/routes/middleware/adminBearer.ts
+++ b/src/entities/Event/routes/middleware/adminBearer.ts
@@ -1,9 +1,11 @@
 import { createHash, timingSafeEqual } from "crypto"
 
+import { auth } from "decentraland-gatsby/dist/entities/Auth/middleware"
+import { withAuthProfile } from "decentraland-gatsby/dist/entities/Profile/middleware"
 import RequestError from "decentraland-gatsby/dist/entities/Route/error"
 import middleware from "decentraland-gatsby/dist/entities/Route/handle/middleware"
 import env from "decentraland-gatsby/dist/utils/env"
-import { Request } from "express"
+import { NextFunction, Request, Response } from "express"
 
 const ADMIN_TOKEN = env("EVENTS_ADMIN_AUTH_TOKEN", "")
 const BEARER_PREFIX = "Bearer "
@@ -12,6 +14,13 @@ function safeCompare(value: string, expected: string): boolean {
   const valueHash = createHash("sha256").update(value).digest()
   const expectedHash = createHash("sha256").update(expected).digest()
   return timingSafeEqual(valueHash, expectedHash)
+}
+
+function hasBearerAuthorization(req: Pick<Request, "headers">): boolean {
+  const authorization = req.headers.authorization
+  return (
+    typeof authorization === "string" && authorization.startsWith(BEARER_PREFIX)
+  )
 }
 
 export async function assertAdminBearer(req: Pick<Request, "headers">) {
@@ -37,3 +46,44 @@ export async function assertAdminBearer(req: Pick<Request, "headers">) {
 }
 
 export const adminBearer = middleware(assertAdminBearer)
+
+export function adminBearerOrAuth(options?: { withProfile?: boolean }) {
+  const userAuth = auth()
+  const userProfile = options?.withProfile ? withAuthProfile() : null
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (hasBearerAuthorization(req)) {
+      assertAdminBearer(req)
+        .then(() => {
+          ;(req as Request & { isAdminBearer?: boolean }).isAdminBearer = true
+          next()
+        })
+        .catch(next)
+      return
+    }
+
+    userAuth(req, res, (err?: unknown) => {
+      if (err) return next(err as Error)
+      if (!userProfile) return next()
+      userProfile(req, res, next)
+    })
+  }
+}
+
+export function adminBearerOrOptionalAuth() {
+  const userAuth = auth({ optional: true })
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (hasBearerAuthorization(req)) {
+      assertAdminBearer(req)
+        .then(() => {
+          ;(req as Request & { isAdminBearer?: boolean }).isAdminBearer = true
+          next()
+        })
+        .catch(next)
+      return
+    }
+
+    userAuth(req, res, next)
+  }
+}

--- a/src/entities/Event/routes/updateEvent.test.ts
+++ b/src/entities/Event/routes/updateEvent.test.ts
@@ -160,6 +160,7 @@ function createBaseEvent(
     schedules: [],
     approved_by: null,
     rejected_by: null,
+    rejection_reason: null,
     world: false,
     place_id: null,
     community_id: null,
@@ -372,6 +373,80 @@ describe("updateEvent", () => {
           expect.objectContaining({ name: "Admin Updated Name" }),
           { id: EVENT_ID }
         )
+      })
+    })
+
+    describe("and is an admin rejecting the event with a reason", () => {
+      let event: DeprecatedEventAttributes
+      let profile: ProfileSettingsSessionAttributes
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        event = createBaseEvent({
+          approved: true,
+          highlighted: true,
+          trending: true,
+        })
+        profile = createProfileSettings(OTHER_USER_ADDRESS)
+        req = createRequest(OTHER_USER_ADDRESS, {
+          rejected: true,
+          rejection_reason: "Suspicious external URL",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(true)
+        ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+        ;(EventModel.textsearch as jest.Mock).mockReturnValueOnce(null)
+        ;(EventModel.selectNextStartAt as jest.Mock).mockReturnValueOnce(
+          new Date("2030-01-01T00:00:00Z")
+        )
+        ;(EventModel.toPublic as jest.Mock).mockReturnValueOnce({})
+        ;(EventAttendeeModel.findOne as jest.Mock).mockResolvedValueOnce(null)
+        ;(
+          EventCategoryModel.validateCategories as jest.Mock
+        ).mockResolvedValueOnce(true)
+      })
+
+      it("should persist the rejection reason and clear approval state", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            approved: false,
+            rejected: true,
+            rejected_by: OTHER_USER_ADDRESS,
+            rejection_reason: "Suspicious external URL",
+            highlighted: false,
+            trending: false,
+          }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and is an admin rejecting the event with an empty reason", () => {
+      let event: DeprecatedEventAttributes
+      let profile: ProfileSettingsSessionAttributes
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        event = createBaseEvent()
+        profile = createProfileSettings(OTHER_USER_ADDRESS)
+        req = createRequest(OTHER_USER_ADDRESS, {
+          rejected: true,
+          rejection_reason: "   ",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(true)
+      })
+
+      it("should reject the update without persisting changes", async () => {
+        await expect(updateEvent(req)).rejects.toThrow(
+          "rejection_reason cannot be empty"
+        )
+
+        expect(EventModel.update).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -39,19 +39,19 @@ import {
   EventAttributes,
   MAX_EVENT_DURATION,
   MAX_RECURRENT_PAST_ITERATIONS,
+  MAX_REJECTION_REASON_LENGTH,
   approveEventAttributes,
   editAnyEventAttributes,
   editEventAttributes,
   editOwnEventAttributes,
 } from "../types"
 import {
+  JUMP_IN_SITE_URL,
   calculateRecurrentProperties,
   estimateRecurrentPastIterations,
   eventTargetUrl,
   validateImageUrl,
 } from "../utils"
-
-import { JUMP_IN_SITE_URL } from "./index"
 
 const validateUpdateEvent = createValidator<DeprecatedEventAttributes>(
   newEventSchema as AjvObjectSchema
@@ -61,7 +61,6 @@ const EVENTS_BASE_URL = env(
   "EVENTS_BASE_URL",
   "https://events.decentraland.org"
 )
-const MAX_REJECTION_REASON_LENGTH = 500
 
 function normalizeRejectionReason(value: unknown): string | null {
   if (value === null) {

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -39,10 +39,10 @@ import {
   EventAttributes,
   MAX_EVENT_DURATION,
   MAX_RECURRENT_PAST_ITERATIONS,
-  MAX_REJECTION_REASON_LENGTH,
   approveEventAttributes,
   editAnyEventAttributes,
   editEventAttributes,
+  editEventAttributesWithoutRejected,
   editOwnEventAttributes,
 } from "../types"
 import {
@@ -51,6 +51,7 @@ import {
   estimateRecurrentPastIterations,
   eventTargetUrl,
   validateImageUrl,
+  validateRejectionReason,
 } from "../utils"
 
 const validateUpdateEvent = createValidator<DeprecatedEventAttributes>(
@@ -62,45 +63,11 @@ const EVENTS_BASE_URL = env(
   "https://events.decentraland.org"
 )
 
-const adminEditEventAttributes = editEventAttributes.filter(
-  (attribute) => attribute !== "rejected"
-)
-
 export type UpdateEventOptions = {
   event?: DeprecatedEventAttributes
   profile?: Awaited<ReturnType<typeof getAuthProfileSettings>>
   actor?: string
   admin?: boolean
-}
-
-function normalizeRejectionReason(value: unknown): string | null {
-  if (value === null) {
-    return null
-  }
-
-  if (typeof value !== "string") {
-    throw new RequestError(
-      "rejection_reason must be a string",
-      RequestError.BadRequest
-    )
-  }
-
-  const reason = value.trim()
-  if (!reason) {
-    throw new RequestError(
-      "rejection_reason cannot be empty",
-      RequestError.BadRequest
-    )
-  }
-
-  if (reason.length > MAX_REJECTION_REASON_LENGTH) {
-    throw new RequestError(
-      `rejection_reason must be ${MAX_REJECTION_REASON_LENGTH} characters or less`,
-      RequestError.BadRequest
-    )
-  }
-
-  return reason
 }
 
 async function notifyCommunityMembers(
@@ -149,7 +116,7 @@ export async function updateEventWithOptions(
   if (admin) {
     Object.assign(
       updatedAttributes,
-      pick(req.body, adminEditEventAttributes),
+      pick(req.body, editEventAttributesWithoutRejected),
       pick(event, editOwnEventAttributes),
       pick(req.body, editOwnEventAttributes),
       pick(event, editAnyEventAttributes),
@@ -189,8 +156,10 @@ export async function updateEventWithOptions(
     )
 
     if (req.body.rejection_reason !== undefined) {
-      updatedAttributes.rejection_reason = normalizeRejectionReason(
-        req.body.rejection_reason
+      updatedAttributes.rejection_reason = validateRejectionReason(
+        req.body.rejection_reason,
+        "rejection_reason",
+        { allowNull: true }
       )
     }
   }

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -61,6 +61,37 @@ const EVENTS_BASE_URL = env(
   "EVENTS_BASE_URL",
   "https://events.decentraland.org"
 )
+const MAX_REJECTION_REASON_LENGTH = 500
+
+function normalizeRejectionReason(value: unknown): string | null {
+  if (value === null) {
+    return null
+  }
+
+  if (typeof value !== "string") {
+    throw new RequestError(
+      "rejection_reason must be a string",
+      RequestError.BadRequest
+    )
+  }
+
+  const reason = value.trim()
+  if (!reason) {
+    throw new RequestError(
+      "rejection_reason cannot be empty",
+      RequestError.BadRequest
+    )
+  }
+
+  if (reason.length > MAX_REJECTION_REASON_LENGTH) {
+    throw new RequestError(
+      `rejection_reason must be ${MAX_REJECTION_REASON_LENGTH} characters or less`,
+      RequestError.BadRequest
+    )
+  }
+
+  return reason
+}
 
 async function notifyCommunityMembers(
   event: EventAttributes,
@@ -133,6 +164,12 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
       pick(event, approveEventAttributes),
       pick(req.body, approveEventAttributes)
     )
+
+    if (req.body.rejection_reason !== undefined) {
+      updatedAttributes.rejection_reason = normalizeRejectionReason(
+        req.body.rejection_reason
+      )
+    }
   }
 
   if (

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -62,6 +62,17 @@ const EVENTS_BASE_URL = env(
   "https://events.decentraland.org"
 )
 
+const adminEditEventAttributes = editEventAttributes.filter(
+  (attribute) => attribute !== "rejected"
+)
+
+export type UpdateEventOptions = {
+  event?: DeprecatedEventAttributes
+  profile?: Awaited<ReturnType<typeof getAuthProfileSettings>>
+  actor?: string
+  admin?: boolean
+}
+
 function normalizeRejectionReason(value: unknown): string | null {
   if (value === null) {
     return null
@@ -114,13 +125,17 @@ async function notifyCommunityMembers(
   })
 }
 
-export async function updateEvent(req: WithAuthProfile<WithAuth>) {
-  const user = req.auth!
-  const event = await getEvent(req)
-  const profile = await getAuthProfileSettings(req)
+export async function updateEventWithOptions(
+  req: WithAuthProfile<WithAuth>,
+  options: UpdateEventOptions = {}
+) {
+  const user = options.actor || req.auth!
+  const event = options.event || (await getEvent(req))
+  const profile = options.profile || (await getAuthProfileSettings(req))
+  const admin = !!options.admin
   const isOwner = event.user.toLowerCase() === user.toLowerCase()
 
-  if (!isOwner && !isAdmin(user) && !canEditAnyEvent(profile)) {
+  if (!admin && !isOwner && !isAdmin(user) && !canEditAnyEvent(profile)) {
     throw new RequestError(
       "You don't have permission to edit this event",
       RequestError.Forbidden
@@ -131,7 +146,16 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
     ...pick(event, editEventAttributes),
   } as DeprecatedEventAttributes
 
-  if (isOwner) {
+  if (admin) {
+    Object.assign(
+      updatedAttributes,
+      pick(req.body, adminEditEventAttributes),
+      pick(event, editOwnEventAttributes),
+      pick(req.body, editOwnEventAttributes),
+      pick(event, editAnyEventAttributes),
+      pick(req.body, editAnyEventAttributes)
+    )
+  } else if (isOwner) {
     Object.assign(
       updatedAttributes,
       pick(req.body, editEventAttributes),
@@ -148,7 +172,7 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
     }
   }
 
-  if (isAdmin(user) || canEditAnyEvent(profile)) {
+  if (!admin && (isAdmin(user) || canEditAnyEvent(profile))) {
     Object.assign(
       updatedAttributes,
       pick(req.body, editEventAttributes),
@@ -157,7 +181,7 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
     )
   }
 
-  if (isAdmin(user) || canApproveAnyEvent(profile)) {
+  if (!admin && (isAdmin(user) || canApproveAnyEvent(profile))) {
     Object.assign(
       updatedAttributes,
       pick(event, approveEventAttributes),
@@ -343,7 +367,7 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
     updatedAttributes.trending = false
   }
 
-  const updatedEvent = {
+  const updatedEvent: DeprecatedEventAttributes & { attending?: boolean } = {
     ...event,
     ...updatedAttributes,
   }
@@ -360,7 +384,7 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
   // Community validation is only needed if the event is being updated by the owner
   const needsCommunityValidation = updatedAttributes.community_id !== undefined
 
-  if (needsCommunityValidation) {
+  if (!admin && needsCommunityValidation) {
     try {
       const userCommunities = await Communities.get().getCommunitiesWithToken(
         user
@@ -437,14 +461,18 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
     }
   }
 
-  const attendee = await EventAttendeeModel.findOne<EventAttendeeAttributes>({
-    event_id: event.id,
-    user,
-  })
+  if (!admin) {
+    const attendee = await EventAttendeeModel.findOne<EventAttendeeAttributes>({
+      event_id: event.id,
+      user,
+    })
 
-  updatedEvent.attending = !!attendee
+    updatedEvent.attending = !!attendee
+  }
 
-  if (!event.approved && updatedEvent.approved) {
+  if (admin) {
+    notifyEditedEvent(updatedEvent)
+  } else if (!event.approved && updatedEvent.approved) {
     notifyApprovedEvent(updatedEvent)
   } else if (!event.rejected && updatedEvent.rejected) {
     notifyRejectedEvent(updatedEvent)
@@ -453,4 +481,8 @@ export async function updateEvent(req: WithAuthProfile<WithAuth>) {
   }
 
   return EventModel.toPublic(updatedEvent, profile)
+}
+
+export async function updateEvent(req: WithAuthProfile<WithAuth>) {
+  return updateEventWithOptions(req)
 }

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -248,6 +248,11 @@ export const eventSchema = {
       type: "boolean",
       description: "True if the event was rejected by an admin",
     },
+    rejection_reason: {
+      type: ["string", "null"],
+      maxLength: 500,
+      description: "Reason provided by the moderator when rejecting the event",
+    },
     trending: {
       type: "boolean",
       description: "True if the event is tending",
@@ -370,13 +375,11 @@ export const eventSchema = {
     },
     approved_by: {
       descrioption: "The user who approved the event",
-      type: "string",
-      format: "address",
+      type: ["string", "null"],
     },
     rejected_by: {
       descrioption: "The user who rejected the event",
-      type: "string",
-      format: "address",
+      type: ["string", "null"],
     },
     attending: {
       type: "boolean",
@@ -484,6 +487,10 @@ export const newEventSchema = {
     },
     rejected: {
       type: "boolean",
+    },
+    rejection_reason: {
+      type: ["string", "null"],
+      maxLength: 500,
     },
     highlighted: {
       type: "boolean",

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -374,11 +374,11 @@ export const eventSchema = {
       },
     },
     approved_by: {
-      descrioption: "The user who approved the event",
+      description: "The user who approved the event",
       type: ["string", "null"],
     },
     rejected_by: {
-      descrioption: "The user who rejected the event",
+      description: "The user who rejected the event",
       type: ["string", "null"],
     },
     attending: {

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -145,6 +145,14 @@ export const getEventListQuery: AjvObjectSchema = {
       description:
         "Include the list of connected user wallet addresses for each event location (connected_addresses property). Data is cached for 5 minutes.",
     },
+    approved: {
+      enum: ["true", "false", "1", "0"],
+      description: "Admin-only filter for event approval state",
+    },
+    rejected: {
+      enum: ["true", "false", "1", "0"],
+      description: "Admin-only filter for event rejection state",
+    },
   },
 }
 

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -97,6 +97,9 @@ export enum Position {
 
 export const MAX_EVENT_RECURRENT = 10
 
+export const MAX_REJECTION_REASON_LENGTH = 500
+export const MAX_ADMIN_ACTOR_LENGTH = 42
+
 // Upper bound on how many past occurrences rrule is asked to step through
 // when expanding a recurrence. Past iterations happen inside rrule's inner
 // loop (even with .between) and are bounded by (now - start_at) / period.

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -230,6 +230,8 @@ export type EventListParams = {
   from?: string // ISO 8601 date-time string
   to?: string // ISO 8601 date-time string
   with_connected_users?: boolean
+  approved?: boolean
+  rejected?: boolean
 }
 
 export type EventListOptions = {

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -287,9 +287,7 @@ export const editEventAttributes = [
 
 export const editEventAttributesWithoutRejected = editEventAttributes.filter(
   (attribute) => attribute !== "rejected"
-) as ReadonlyArray<
-  Exclude<(typeof editEventAttributes)[number], "rejected">
->
+) as ReadonlyArray<Exclude<(typeof editEventAttributes)[number], "rejected">>
 
 export const editOwnEventAttributes = [
   "contact",

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -163,6 +163,7 @@ export type EventAttributes = {
   schedules: string[]
   approved_by: string | null
   rejected_by: string | null
+  rejection_reason: string | null
   world: boolean
   place_id: string | null
   community_id: string | null
@@ -230,6 +231,7 @@ export type EventListParams = {
 
 export type EventListOptions = {
   allow_pending?: boolean
+  include_rejected?: boolean
   list?: EventListType
   user?: string
   creator?: string
@@ -249,6 +251,8 @@ export type EventListOptions = {
   order?: "asc" | "desc"
   from?: Date // Start of date range filter
   to?: Date // End of date range filter
+  approved?: boolean
+  rejected?: boolean
 }
 
 export const editEventAttributes = [

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -285,6 +285,12 @@ export const editEventAttributes = [
   "world",
 ] as const
 
+export const editEventAttributesWithoutRejected = editEventAttributes.filter(
+  (attribute) => attribute !== "rejected"
+) as ReadonlyArray<
+  Exclude<(typeof editEventAttributes)[number], "rejected">
+>
+
 export const editOwnEventAttributes = [
   "contact",
   "details",

--- a/src/entities/Event/utils.ts
+++ b/src/entities/Event/utils.ts
@@ -21,7 +21,7 @@ import {
 import { mainRealmUrl } from "../../modules/servers"
 import { ScheduleAttributes } from "../Schedule/types"
 
-const JUMP_IN_SITE_URL = env(
+export const JUMP_IN_SITE_URL = env(
   "JUMP_IN_SITE_URL",
   "https://decentraland.org/jump"
 )

--- a/src/entities/Event/utils.ts
+++ b/src/entities/Event/utils.ts
@@ -11,6 +11,7 @@ import {
   EventType,
   FREQUENCY_PERIOD_MS,
   MAX_EVENT_RECURRENT,
+  MAX_REJECTION_REASON_LENGTH,
   MonthMask,
   Months,
   Position,
@@ -553,6 +554,56 @@ export function isPastEvent(event: EventAttributes) {
   const now = Date.now()
   const finish_at = Time.date(event.finish_at)
   return finish_at.getTime() < now
+}
+
+export function validateRejectionReason(
+  value: unknown,
+  fieldName: string
+): string
+export function validateRejectionReason(
+  value: unknown,
+  fieldName: string,
+  options: { allowNull: true }
+): string | null
+export function validateRejectionReason(
+  value: unknown,
+  fieldName: string,
+  options: { allowNull?: boolean } = {}
+): string | null {
+  if (value === null && options.allowNull) {
+    return null
+  }
+
+  if (value === undefined || value === null) {
+    throw new RequestError(
+      `${fieldName} is required`,
+      RequestError.BadRequest
+    )
+  }
+
+  if (typeof value !== "string") {
+    throw new RequestError(
+      `${fieldName} must be a string`,
+      RequestError.BadRequest
+    )
+  }
+
+  const reason = value.trim()
+  if (!reason) {
+    throw new RequestError(
+      `${fieldName} cannot be empty`,
+      RequestError.BadRequest
+    )
+  }
+
+  if (reason.length > MAX_REJECTION_REASON_LENGTH) {
+    throw new RequestError(
+      `${fieldName} must be ${MAX_REJECTION_REASON_LENGTH} characters or less`,
+      RequestError.BadRequest
+    )
+  }
+
+  return reason
 }
 
 export async function validateImageUrl(imageUrl: string) {

--- a/src/entities/Event/utils.ts
+++ b/src/entities/Event/utils.ts
@@ -575,10 +575,7 @@ export function validateRejectionReason(
   }
 
   if (value === undefined || value === null) {
-    throw new RequestError(
-      `${fieldName} is required`,
-      RequestError.BadRequest
-    )
+    throw new RequestError(`${fieldName} is required`, RequestError.BadRequest)
   }
 
   if (typeof value !== "string") {

--- a/src/entities/Slack/utils.ts
+++ b/src/entities/Slack/utils.ts
@@ -118,14 +118,19 @@ export async function notifyRejectedEvent(event: DeprecatedEventAttributes) {
         type: "section",
         text: {
           type: "plain_text",
-          text: "Name: " + event.name,
+          text: [
+            "Name: " + event.name,
+            event.rejection_reason && "Reason: " + event.rejection_reason,
+          ]
+            .filter(Boolean)
+            .join("\n"),
         },
       },
-      event.approved_by && {
+      event.rejected_by && {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `\n_by:_ \`${event.approved_by}\`` + selfRejected,
+          text: `\n_by:_ \`${event.rejected_by}\`` + selfRejected,
         },
       },
     ].filter(Boolean),

--- a/src/migrations/1776902400000_add-rejection-reason-to-events.ts
+++ b/src/migrations/1776902400000_add-rejection-reason-to-events.ts
@@ -1,0 +1,19 @@
+import { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate"
+
+import EventModel from "../entities/Event/model"
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(EventModel.tableName, {
+    rejection_reason: {
+      type: "TEXT",
+      notNull: false,
+      default: null,
+    },
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumns(EventModel.tableName, ["rejection_reason"])
+}

--- a/test/integration/getEvents.test.ts
+++ b/test/integration/getEvents.test.ts
@@ -1,0 +1,389 @@
+import { AuthIdentity } from "@dcl/crypto/dist/types"
+import supertest from "supertest"
+
+import { signedHeaderFactory } from "decentraland-crypto-fetch"
+
+import { DeprecatedEventAttributes } from "../../src/entities/Event/types"
+import { seedEvent } from "../mocks/event"
+import { createIdentity } from "../mocks/identity"
+import { cleanTables, closeTestDb, initTestDb } from "../setup/db"
+import { createTestApp } from "../setup/server"
+
+jest.mock("decentraland-gatsby/dist/utils/env", () => {
+  return jest.fn((key: string, defaultValue?: string) => {
+    if (key === "EVENTS_ADMIN_AUTH_TOKEN") {
+      return "integration-events-admin-token"
+    }
+
+    return process.env[key] ?? defaultValue
+  })
+})
+
+jest.mock("decentraland-gatsby/dist/utils/api/API", () => {
+  class MockAPI {
+    static catch = () => Promise.resolve(null)
+  }
+  return MockAPI
+})
+
+const mockGetProfiles = jest.fn().mockResolvedValue([])
+jest.mock("decentraland-gatsby/dist/utils/api/Catalyst", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({ getProfiles: mockGetProfiles }),
+  },
+}))
+
+jest.mock("decentraland-gatsby/dist/utils/api/Land", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getTile: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../../src/api/Places", () => ({
+  __esModule: true,
+  default: {
+    get: () => ({
+      getPlaceByPosition: () => Promise.resolve(null),
+      getWorldByName: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../../src/api/Communities", () => ({
+  __esModule: true,
+  default: {
+    get: () => ({
+      getCommunitiesWithToken: () => Promise.resolve([]),
+      getCommunityMembers: () => Promise.resolve([]),
+      getCommunity: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../../src/entities/Notifications", () => ({
+  sendEventCreated: jest.fn(),
+  sendEventStarted: jest.fn(),
+  sendEventStartsSoon: jest.fn(),
+  sendEventEnded: jest.fn(),
+}))
+
+jest.mock("../../src/entities/Slack/utils", () => ({
+  notifyApprovedEvent: jest.fn(),
+  notifyEditedEvent: jest.fn(),
+  notifyRejectedEvent: jest.fn(),
+}))
+
+const ADMIN_TOKEN = "integration-events-admin-token"
+const app = createTestApp()
+let dbInitialized = false
+
+function adminRequest(request: supertest.Test): supertest.Test {
+  return request.set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+}
+
+function signedGet(identity: AuthIdentity, path: string) {
+  const createHeaders = signedHeaderFactory()
+  const headers = createHeaders(identity, "GET", path, {})
+
+  const headerObj: Record<string, string> = {}
+  headers.forEach((value: string, key: string) => {
+    headerObj[key] = value
+  })
+
+  return supertest(app).get(path).set(headerObj)
+}
+
+describe("GET /api/events", () => {
+  beforeAll(async () => {
+    await initTestDb()
+    dbInitialized = true
+  })
+
+  afterAll(async () => {
+    if (dbInitialized) {
+      await closeTestDb()
+    }
+  })
+
+  afterEach(async () => {
+    if (dbInitialized) {
+      await cleanTables()
+    }
+    jest.clearAllMocks()
+  })
+
+  describe("when the request is public", () => {
+    let approvedEvent: DeprecatedEventAttributes
+    let pendingEvent: DeprecatedEventAttributes
+    let rejectedEvent: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      approvedEvent = await seedEvent({
+        approved: true,
+        name: "Approved Public Event",
+      })
+      pendingEvent = await seedEvent({
+        approved: false,
+        name: "Pending Public Event",
+      })
+      rejectedEvent = await seedEvent({
+        approved: false,
+        name: "Rejected Public Event",
+        rejected: true,
+        rejection_reason: "Spam",
+      })
+      response = await supertest(app).get("/api/events")
+    })
+
+    it("should only list approved non-rejected events", async () => {
+      const eventIds = response.body.data.map(
+        (event: DeprecatedEventAttributes) => event.id
+      )
+
+      expect(response.status).toBe(200)
+      expect(eventIds).toContain(approvedEvent.id)
+      expect(eventIds).not.toContain(pendingEvent.id)
+      expect(eventIds).not.toContain(rejectedEvent.id)
+    })
+  })
+
+  describe("when the public request includes admin-only state filters", () => {
+    let approvedEvent: DeprecatedEventAttributes
+    let pendingEvent: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      approvedEvent = await seedEvent({ approved: true })
+      pendingEvent = await seedEvent({ approved: false })
+      response = await supertest(app).get(
+        "/api/events?approved=false&rejected=false"
+      )
+    })
+
+    it("should ignore those filters and keep public visibility rules", async () => {
+      const eventIds = response.body.data.map(
+        (event: DeprecatedEventAttributes) => event.id
+      )
+
+      expect(response.status).toBe(200)
+      expect(eventIds).toContain(approvedEvent.id)
+      expect(eventIds).not.toContain(pendingEvent.id)
+    })
+  })
+
+  describe("when the request uses the admin bearer token", () => {
+    let approvedEvent: DeprecatedEventAttributes
+    let pendingEvent: DeprecatedEventAttributes
+    let rejectedEvent: DeprecatedEventAttributes
+    let otherCreatorEvent: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      approvedEvent = await seedEvent({
+        approved: true,
+        name: "Approved Event",
+        user: "0x1111111111111111111111111111111111111111",
+      })
+      pendingEvent = await seedEvent({
+        approved: false,
+        name: "Pending Event",
+        user: "0x1111111111111111111111111111111111111111",
+      })
+      rejectedEvent = await seedEvent({
+        approved: false,
+        name: "Rejected Event",
+        rejected: true,
+        rejection_reason: "Spam",
+        user: "0x1111111111111111111111111111111111111111",
+      })
+      otherCreatorEvent = await seedEvent({
+        approved: false,
+        name: "Other Creator Event",
+        user: "0x2222222222222222222222222222222222222222",
+      })
+      response = await adminRequest(supertest(app).get("/api/events"))
+    })
+
+    it("should include approved, pending, and rejected events", async () => {
+      const eventIds = response.body.data.map(
+        (event: DeprecatedEventAttributes) => event.id
+      )
+
+      expect(response.status).toBe(200)
+      expect(eventIds).toContain(approvedEvent.id)
+      expect(eventIds).toContain(pendingEvent.id)
+      expect(eventIds).toContain(rejectedEvent.id)
+      expect(eventIds).toContain(otherCreatorEvent.id)
+    })
+  })
+
+  describe("when admin filters are combined with regular filters", () => {
+    let matchingEvent: DeprecatedEventAttributes
+    let wrongCreatorEvent: DeprecatedEventAttributes
+    let wrongStateEvent: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      matchingEvent = await seedEvent({
+        approved: false,
+        name: "Matching Pending Event",
+        user: "0x1111111111111111111111111111111111111111",
+      })
+      wrongCreatorEvent = await seedEvent({
+        approved: false,
+        name: "Wrong Creator Pending Event",
+        user: "0x2222222222222222222222222222222222222222",
+      })
+      wrongStateEvent = await seedEvent({
+        approved: true,
+        name: "Approved Creator Event",
+        user: "0x1111111111111111111111111111111111111111",
+      })
+      response = await adminRequest(
+        supertest(app).get(
+          "/api/events?approved=false&rejected=false&creator=0x1111111111111111111111111111111111111111"
+        )
+      )
+    })
+
+    it("should preserve regular filters and apply admin state filters", async () => {
+      const eventIds = response.body.data.map(
+        (event: DeprecatedEventAttributes) => event.id
+      )
+
+      expect(response.status).toBe(200)
+      expect(eventIds).toContain(matchingEvent.id)
+      expect(eventIds).not.toContain(wrongCreatorEvent.id)
+      expect(eventIds).not.toContain(wrongStateEvent.id)
+    })
+  })
+})
+
+describe("GET /api/events/:event_id", () => {
+  beforeAll(async () => {
+    await initTestDb()
+    dbInitialized = true
+  })
+
+  afterAll(async () => {
+    if (dbInitialized) {
+      await closeTestDb()
+    }
+  })
+
+  afterEach(async () => {
+    if (dbInitialized) {
+      await cleanTables()
+    }
+    jest.clearAllMocks()
+  })
+
+  describe("when the event is approved and the request is public", () => {
+    let event: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      event = await seedEvent({
+        approved: true,
+        contact: "owner@example.com",
+        details: "Private details",
+      })
+      response = await supertest(app).get(`/api/events/${event.id}`)
+    })
+
+    it("should return the event without owner-only fields", async () => {
+      expect(response.status).toBe(200)
+      expect(response.body.data.id).toBe(event.id)
+      expect(response.body.data.contact).toBeUndefined()
+      expect(response.body.data.details).toBeUndefined()
+    })
+  })
+
+  describe("when the event is pending and the request is public", () => {
+    let event: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      event = await seedEvent({ approved: false })
+      response = await supertest(app).get(`/api/events/${event.id}`)
+    })
+
+    it("should respond with 404 Not Found", async () => {
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe("when the event is rejected and the request is public", () => {
+    let event: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      event = await seedEvent({
+        approved: false,
+        rejected: true,
+        rejection_reason: "Spam",
+      })
+      response = await supertest(app).get(`/api/events/${event.id}`)
+    })
+
+    it("should respond with 404 Not Found", async () => {
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe("when the requester owns a pending event", () => {
+    let event: DeprecatedEventAttributes
+    let ownerIdentity: AuthIdentity
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      const owner = await createIdentity()
+      ownerIdentity = owner.identity
+      event = await seedEvent({
+        approved: false,
+        contact: "owner@example.com",
+        details: "Private details",
+        user: owner.address,
+      })
+      response = await signedGet(ownerIdentity, `/api/events/${event.id}`)
+    })
+
+    it("should return the event with owner-only fields", async () => {
+      expect(response.status).toBe(200)
+      expect(response.body.data.id).toBe(event.id)
+      expect(response.body.data.contact).toBe("owner@example.com")
+      expect(response.body.data.details).toBe("Private details")
+    })
+  })
+
+  describe("when the event is rejected and the request uses the admin bearer token", () => {
+    let event: DeprecatedEventAttributes
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      event = await seedEvent({
+        approved: false,
+        contact: "owner@example.com",
+        details: "Private details",
+        rejected: true,
+        rejection_reason: "Spam",
+      })
+      response = await adminRequest(
+        supertest(app).get(`/api/events/${event.id}`)
+      )
+    })
+
+    it("should return the event and include owner-only fields", async () => {
+      expect(response.status).toBe(200)
+      expect(response.body.data.id).toBe(event.id)
+      expect(response.body.data.rejected).toBe(true)
+      expect(response.body.data.contact).toBe("owner@example.com")
+      expect(response.body.data.details).toBe("Private details")
+    })
+  })
+})

--- a/test/integration/updateEvent.test.ts
+++ b/test/integration/updateEvent.test.ts
@@ -3,6 +3,7 @@ import supertest from "supertest"
 
 import { signedHeaderFactory } from "decentraland-crypto-fetch"
 
+import EventModel from "../../src/entities/Event/model"
 import { DeprecatedEventAttributes } from "../../src/entities/Event/types"
 import { ProfilePermissions } from "../../src/entities/ProfileSettings/types"
 import { seedEvent } from "../mocks/event"
@@ -10,6 +11,16 @@ import { createIdentity } from "../mocks/identity"
 import { seedProfileSettings } from "../mocks/profileSettings"
 import { cleanTables, closeTestDb, initTestDb } from "../setup/db"
 import { createTestApp } from "../setup/server"
+
+jest.mock("decentraland-gatsby/dist/utils/env", () => {
+  return jest.fn((key: string, defaultValue?: string) => {
+    if (key === "EVENTS_ADMIN_AUTH_TOKEN") {
+      return "integration-events-admin-token"
+    }
+
+    return process.env[key] ?? defaultValue
+  })
+})
 
 jest.mock("decentraland-gatsby/dist/utils/api/API", () => {
   class MockAPI {
@@ -70,6 +81,9 @@ jest.mock("../../src/entities/Slack/utils", () => ({
 }))
 
 const app = createTestApp()
+const ADMIN_TOKEN = "integration-events-admin-token"
+const ACTOR = "jarvis-agent"
+let dbInitialized = false
 
 function signedPatch(
   identity: AuthIdentity,
@@ -87,17 +101,26 @@ function signedPatch(
   return supertest(app).patch(path).set(headerObj).send(body)
 }
 
+function adminRequest(request: supertest.Test): supertest.Test {
+  return request.set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+}
+
 describe("PATCH /api/events/:event_id", () => {
   beforeAll(async () => {
     await initTestDb()
+    dbInitialized = true
   })
 
   afterAll(async () => {
-    await closeTestDb()
+    if (dbInitialized) {
+      await closeTestDb()
+    }
   })
 
   afterEach(async () => {
-    await cleanTables()
+    if (dbInitialized) {
+      await cleanTables()
+    }
     jest.clearAllMocks()
   })
 
@@ -591,6 +614,135 @@ describe("PATCH /api/events/:event_id", () => {
         expect(response.body.data.x).toBe(50)
         expect(response.body.data.y).toBe(-30)
         expect(response.body.data.position).toEqual([50, -30])
+      })
+    })
+  })
+
+  describe("when the request uses the admin bearer token", () => {
+    describe("and approves an event", () => {
+      let event: DeprecatedEventAttributes
+      let response: supertest.Response
+      let storedEvent: DeprecatedEventAttributes | null
+
+      beforeEach(async () => {
+        event = await seedEvent({
+          approved: false,
+          rejected: true,
+          rejected_by: "previous-admin",
+          rejection_reason: "Previous reason",
+        })
+        response = await adminRequest(
+          supertest(app).patch(`/api/events/${event.id}`).send({
+            approved: true,
+          })
+        )
+        storedEvent = await EventModel.findOne<DeprecatedEventAttributes>({
+          id: event.id,
+        })
+      })
+
+      it("should approve the event and clear rejection state", async () => {
+        expect(response.status).toBe(201)
+        expect(response.body.data.approved).toBe(true)
+        expect(response.body.data.approved_by).toBe(ACTOR)
+        expect(response.body.data.rejected).toBe(false)
+        expect(response.body.data.rejection_reason).toBeNull()
+        expect(storedEvent?.approved).toBe(true)
+        expect(storedEvent?.approved_by?.trim()).toBe(ACTOR)
+        expect(storedEvent?.rejected).toBe(false)
+        expect(storedEvent?.rejection_reason).toBeNull()
+      })
+    })
+
+    describe("and rejects an event", () => {
+      let event: DeprecatedEventAttributes
+      let response: supertest.Response
+      let storedEvent: DeprecatedEventAttributes | null
+
+      beforeEach(async () => {
+        event = await seedEvent({
+          approved: true,
+          highlighted: true,
+          rejected: false,
+          trending: true,
+        })
+        response = await adminRequest(
+          supertest(app).patch(`/api/events/${event.id}`).send({
+            rejected: true,
+            reason: "Invalid content",
+          })
+        )
+        storedEvent = await EventModel.findOne<DeprecatedEventAttributes>({
+          id: event.id,
+        })
+      })
+
+      it("should reject the event and store the rejection reason", async () => {
+        expect(response.status).toBe(201)
+        expect(response.body.data.approved).toBe(false)
+        expect(response.body.data.highlighted).toBe(false)
+        expect(response.body.data.rejected).toBe(true)
+        expect(response.body.data.rejected_by).toBe(ACTOR)
+        expect(response.body.data.rejection_reason).toBe("Invalid content")
+        expect(response.body.data.trending).toBe(false)
+        expect(storedEvent?.approved).toBe(false)
+        expect(storedEvent?.highlighted).toBe(false)
+        expect(storedEvent?.rejected).toBe(true)
+        expect(storedEvent?.rejected_by?.trim()).toBe(ACTOR)
+        expect(storedEvent?.rejection_reason).toBe("Invalid content")
+        expect(storedEvent?.trending).toBe(false)
+      })
+    })
+
+    describe("and edits event fields", () => {
+      let event: DeprecatedEventAttributes
+      let response: supertest.Response
+      let storedEvent: DeprecatedEventAttributes | null
+
+      beforeEach(async () => {
+        event = await seedEvent({
+          approved: true,
+          name: "Original Name",
+          x: 0,
+          y: 0,
+        })
+        response = await adminRequest(
+          supertest(app).patch(`/api/events/${event.id}`).send({
+            name: "Admin Updated Name",
+            x: 10,
+            y: -10,
+          })
+        )
+        storedEvent = await EventModel.findOne<DeprecatedEventAttributes>({
+          id: event.id,
+        })
+      })
+
+      it("should reuse the update pipeline and persist the edit", async () => {
+        expect(response.status).toBe(201)
+        expect(response.body.data.name).toBe("Admin Updated Name")
+        expect(response.body.data.position).toEqual([10, -10])
+        expect(storedEvent?.name).toBe("Admin Updated Name")
+        expect(storedEvent?.x).toBe(10)
+        expect(storedEvent?.y).toBe(-10)
+        expect(storedEvent?.coordinates).toEqual([10, -10])
+      })
+    })
+
+    describe("and the bearer token is invalid", () => {
+      let event: DeprecatedEventAttributes
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        event = await seedEvent({ approved: true })
+        response = await supertest(app)
+          .patch(`/api/events/${event.id}`)
+          .set("Authorization", "Bearer invalid-token")
+          .send({ approved: true })
+      })
+
+      it("should respond with 401 Unauthorized", async () => {
+        expect(response.status).toBe(401)
       })
     })
   })

--- a/test/mocks/event.ts
+++ b/test/mocks/event.ts
@@ -55,6 +55,7 @@ export async function seedEvent(
     schedules: [],
     approved_by: null,
     rejected_by: null,
+    rejection_reason: null,
     world: false,
     place_id: null,
     community_id: null,


### PR DESCRIPTION
Introduces service-to-service admin endpoints under `/events/admin`, `/events/:event_id/admin`, `/events/:event_id/approved`, and `/events/:event_id/rejected`, guarded by a shared bearer token (`EVENTS_ADMIN_AUTH_TOKEN`) with `timingSafeEqual` comparison over SHA-256 hashes.

The reject flow now persists `rejection_reason` (new column) so moderators see the reason they applied. Slack notifications for rejections report the actual rejector (previously they read `approved_by`).

## Endpoints
- `GET /events/admin?approved&rejected&limit&offset` — list including pending/rejected rows
- `GET /events/:event_id/admin` — fetch any event regardless of approval state
- `PUT /events/:event_id/approved` — approve; clears rejection state, records actor
- `DELETE /events/:event_id/approved` — unapprove
- `PUT /events/:event_id/rejected` — reject with required `reason`; clears approval/highlight/trending
- `DELETE /events/:event_id/rejected` — unreject
- `PATCH /events/:event_id/admin` — edit content fields as an admin service

## Notes
- `approved_by` and `rejected_by` schemas relaxed from `address` to `string | null` so service actors (`jarvis-agent` by default) are valid.
- Existing `PATCH /events/:event_id` accepts `rejection_reason` when the caller is admin / can approve any event, keeping parity with the rejection flow.
- Migration `1776902400000_add-rejection-reason-to-events.ts` adds the nullable `rejection_reason` column.

## Test plan
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npx tsc -p . --noEmit`
- [x] `npm test` — 156 passed
- [ ] Apply migration in dev
- [ ] Smoke-test admin endpoints with the bearer token in dev