### PR TITLE
feat: add owner filter to events endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -129,11 +129,15 @@ paths:
             - `all`: every event without time restriction
             - `live`: events currently running
             - `upcoming`: future events only
-            - `highlight`: highlighted events with a future finish time
           schema:
             type: string
-            enum: [all, active, live, upcoming, highlight]
+            enum: [all, active, live, upcoming]
             default: active
+        - name: highlighted
+          in: query
+          description: When true, return only events flagged as highlighted. Combine with `list` to scope by time range.
+          schema:
+            type: boolean
         - name: owner
           in: query
           description: |
@@ -341,7 +345,9 @@ paths:
                   minimum: 0
                 list:
                   type: string
-                  enum: [all, active, live, upcoming, highlight, mine]
+                  enum: [all, active, live, upcoming]
+                highlighted:
+                  type: boolean
                 position:
                   type: string
                 positions:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -129,9 +129,10 @@ paths:
             - `all`: every event without time restriction
             - `live`: events currently running
             - `upcoming`: future events only
+            - `highlight`: deprecated alias for `list=active&highlighted=true`
           schema:
             type: string
-            enum: [all, active, live, upcoming]
+            enum: [all, active, live, upcoming, highlight]
             default: active
         - name: highlighted
           in: query
@@ -345,7 +346,7 @@ paths:
                   minimum: 0
                 list:
                   type: string
-                  enum: [all, active, live, upcoming]
+                  enum: [all, active, live, upcoming, highlight]
                 highlighted:
                   type: boolean
                 position:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -123,11 +123,23 @@ paths:
             default: 0
         - name: list
           in: query
-          description: Filter events by time range
+          description: |
+            Filter events by time range.
+            - `active` (default): current and future events
+            - `all`: every event without time restriction
+            - `live`: events currently running
+            - `upcoming`: future events only
+            - `highlight`: highlighted events with a future finish time
           schema:
             type: string
-            enum: [all, active, live, upcoming]
+            enum: [all, active, live, upcoming, highlight]
             default: active
+        - name: owner
+          in: query
+          description: |
+            Return events authored by the authenticated user across all statuses (approved, pending, and rejected). Requires signed-fetch authentication; unauthenticated callers receive 401. Overrides the `creator` filter when set.
+          schema:
+            type: boolean
         - name: position
           in: query
           description: Filter events at a specific Genesis City position (format "x,y")
@@ -262,6 +274,8 @@ paths:
                       $ref: '#/components/schemas/Event'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -327,7 +341,7 @@ paths:
                   minimum: 0
                 list:
                   type: string
-                  enum: [all, active, live, upcoming]
+                  enum: [all, active, live, upcoming, highlight, mine]
                 position:
                   type: string
                 positions:

--- a/src/entities/Event/model.test.ts
+++ b/src/entities/Event/model.test.ts
@@ -231,13 +231,8 @@ describe("EventModel.buildEventFilterConditions", () => {
     })
   })
 
-  describe("when list type filters are provided", () => {
+  describe("when highlighted option is provided", () => {
     const HIGHLIGHTED_FILTER_REGEX = /e\.highlighted\s+IS\s+TRUE/i
-    const ACTIVE_FILTER_REGEX = /e\.next_finish_at\s*>\s*now\(\)/i
-    const LIVE_FILTER_REGEX =
-      /e\.next_finish_at\s*>\s*now\(\)\s*AND\s*e\.next_start_at\s*<\s*now\(\)/i
-    const UPCOMING_FILTER_REGEX =
-      /e\.next_finish_at\s*>\s*now\(\)\s*AND\s*e\.next_start_at\s*>\s*now\(\)/i
 
     function hasHighlightedCondition(conditions: SQLCondition[]): boolean {
       return conditions.some((condition) =>
@@ -245,45 +240,38 @@ describe("EventModel.buildEventFilterConditions", () => {
       )
     }
 
-    describe("and list is Highlight", () => {
-      let options: Partial<EventListOptions>
+    it("generates a highlighted filter condition when highlighted is true", () => {
+      const conditions = buildEventFilterConditions({ highlighted: true })
 
-      beforeEach(() => {
-        options = {
-          list: EventListType.Highlight,
-        }
-      })
-
-      it("generates a highlighted filter condition", () => {
-        const conditions = buildEventFilterConditions(options)
-
-        expect(hasHighlightedCondition(conditions)).toBe(true)
-      })
-
-      it("also filters for active events (next_finish_at > now())", () => {
-        const conditions = buildEventFilterConditions(options)
-        const hasActiveFilter = conditions.some((condition) =>
-          /e\.next_finish_at\s*>\s*now\(\)/.test(condition.text)
-        )
-
-        expect(hasActiveFilter).toBe(true)
-      })
+      expect(hasHighlightedCondition(conditions)).toBe(true)
     })
 
-    describe("and list is Active", () => {
-      let options: Partial<EventListOptions>
+    it("does not generate a highlighted filter condition when highlighted is false", () => {
+      const conditions = buildEventFilterConditions({ highlighted: false })
 
-      beforeEach(() => {
-        options = {
-          list: EventListType.Active,
-        }
+      expect(hasHighlightedCondition(conditions)).toBe(false)
+    })
+
+    it("does not generate a highlighted filter condition when highlighted is omitted", () => {
+      const conditions = buildEventFilterConditions({})
+
+      expect(hasHighlightedCondition(conditions)).toBe(false)
+    })
+
+    it("composes with list=upcoming", () => {
+      const conditions = buildEventFilterConditions({
+        list: EventListType.Upcoming,
+        highlighted: true,
       })
 
-      it("does not generate a highlighted filter condition", () => {
-        const conditions = buildEventFilterConditions(options)
+      const hasUpcoming = conditions.some((c) =>
+        /e\.next_finish_at\s*>\s*now\(\)\s*AND\s*e\.next_start_at\s*>\s*now\(\)/i.test(
+          c.text
+        )
+      )
 
-        expect(hasHighlightedCondition(conditions)).toBe(false)
-      })
+      expect(hasHighlightedCondition(conditions)).toBe(true)
+      expect(hasUpcoming).toBe(true)
     })
   })
 

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -205,10 +205,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         options.list === EventListType.Upcoming,
         SQL`AND e.next_finish_at > now() AND e.next_start_at > now()`
       ),
-      conditional(
-        options.list === EventListType.Highlight,
-        SQL`AND e.highlighted IS TRUE AND e.next_finish_at > now()`
-      ),
+      conditional(options.highlighted === true, SQL`AND e.highlighted IS TRUE`),
       conditional(!!options.search, SQL`AND "rank" > 0`),
       conditional(
         !isOwner && !!options.creator,

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -178,14 +178,18 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         .join(",")
     }
 
+    const isOwner = !!options.owner
+
     return [
-      options.rejected === undefined
+      isOwner
+        ? SQL`lower(e.user) = ${options.user}`
+        : options.rejected === undefined
         ? options.include_rejected
           ? SQL`TRUE`
           : SQL`e.rejected IS FALSE`
         : SQL`e.rejected IS ${SQL.raw(options.rejected ? "TRUE" : "FALSE")}`,
       conditional(
-        options.approved !== undefined,
+        !isOwner && options.approved !== undefined,
         SQL`AND e.approved IS ${SQL.raw(options.approved ? "TRUE" : "FALSE")}`
       ),
       conditional(options.list === EventListType.All, SQL``),
@@ -207,11 +211,11 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       ),
       conditional(!!options.search, SQL`AND "rank" > 0`),
       conditional(
-        !!options.creator,
+        !isOwner && !!options.creator,
         SQL`AND lower(e.user) = ${options.creator}`
       ),
       conditional(
-        !options.allow_pending && !options.user,
+        !isOwner && !options.allow_pending && !options.user,
         SQL`AND e.approved IS TRUE`
       ),
       conditional(!!options.world === true, SQL`AND e.world IS TRUE`),
@@ -220,7 +224,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         SQL`AND e.world IS FALSE`
       ),
       conditional(
-        !options.allow_pending && !!options.user,
+        !isOwner && !options.allow_pending && !!options.user,
         SQL`AND (e.approved IS TRUE OR lower(e.user) = ${options.user})`
       ),
       conditional(

--- a/src/entities/Event/routes/getEventList.ts
+++ b/src/entities/Event/routes/getEventList.ts
@@ -150,6 +150,16 @@ export async function getEventList(
     )
   }
 
+  // Deprecated: `list=highlight` is mapped to `list=active&highlighted=true`.
+  const isLegacyHighlightList =
+    (query.list as string | undefined) === "highlight"
+  const listValue = isLegacyHighlightList
+    ? EventListType.Active
+    : query.list || EventListType.Active
+  const highlightedValue = isLegacyHighlightList
+    ? true
+    : bool(query.highlighted) || undefined
+
   const options: EventListOptions = {
     user: profile.user,
     allow_pending: routeOptions.admin
@@ -162,10 +172,10 @@ export async function getEventList(
     limit: query.limit
       ? Math.min(Math.max(Number(req.query["limit"]), 0), 500)
       : 500,
-    list: query.list || EventListType.Active,
+    list: listValue,
     order: query.order,
     owner: ownerFilter || undefined,
-    highlighted: bool(query.highlighted) || undefined,
+    highlighted: highlightedValue,
   }
 
   if (routeOptions.admin) {

--- a/src/entities/Event/routes/getEventList.ts
+++ b/src/entities/Event/routes/getEventList.ts
@@ -165,6 +165,7 @@ export async function getEventList(
     list: query.list || EventListType.Active,
     order: query.order,
     owner: ownerFilter || undefined,
+    highlighted: bool(query.highlighted) || undefined,
   }
 
   if (routeOptions.admin) {

--- a/src/entities/Event/routes/getEventList.ts
+++ b/src/entities/Event/routes/getEventList.ts
@@ -140,6 +140,16 @@ export async function getEventList(
     ...req.query,
     places_ids: placesIds,
   })
+
+  const ownerFilter = bool(query.owner) ?? false
+
+  if (ownerFilter && !req.auth) {
+    throw new RequestError(
+      "owner filter requires authentication",
+      RequestError.Unauthorized
+    )
+  }
+
   const options: EventListOptions = {
     user: profile.user,
     allow_pending: routeOptions.admin
@@ -154,6 +164,7 @@ export async function getEventList(
       : 500,
     list: query.list || EventListType.Active,
     order: query.order,
+    owner: ownerFilter || undefined,
   }
 
   if (routeOptions.admin) {
@@ -223,7 +234,7 @@ export async function getEventList(
     }
   }
 
-  if (query.creator) {
+  if (query.creator && !ownerFilter) {
     if (isEthereumAddress(query.creator)) {
       options.creator = query.creator.toLowerCase()
     } else {

--- a/src/entities/Event/schemas.test.ts
+++ b/src/entities/Event/schemas.test.ts
@@ -97,6 +97,18 @@ describe("getEventListQuery schema", () => {
       expect(() => validateQuery(query)).toThrow(RequestError)
     })
   })
+
+  describe("when list is the deprecated `highlight` alias", () => {
+    it("should accept the value for backward compatibility", () => {
+      expect(() => validateQuery({ list: "highlight" })).not.toThrow()
+    })
+  })
+
+  describe("when highlighted is a truthy string", () => {
+    it("should accept `true`", () => {
+      expect(() => validateQuery({ highlighted: "true" })).not.toThrow()
+    })
+  })
 })
 
 describe("getEventListByPlacesBodySchema", () => {

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -88,6 +88,11 @@ export const getEventListQuery: AjvObjectSchema = {
           enum: ["upcoming"],
           description: "Only future events",
         },
+        {
+          enum: ["highlight"],
+          description:
+            "Deprecated alias for `list=active&highlighted=true`. Prefer the `highlighted` filter.",
+        },
       ],
     },
     highlighted: {

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -94,6 +94,11 @@ export const getEventListQuery: AjvObjectSchema = {
         },
       ],
     },
+    owner: {
+      enum: TruthyEnum.filter((value) => typeof value === "string"),
+      description:
+        "Return events authored by the authenticated user across all statuses (approved, pending, and rejected). Requires authentication.",
+    },
     order: {
       description: "List order",
       default: "asc",

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -88,11 +88,11 @@ export const getEventListQuery: AjvObjectSchema = {
           enum: ["upcoming"],
           description: "Only future events",
         },
-        {
-          enum: ["highlight"],
-          description: "Only highlighted events",
-        },
       ],
+    },
+    highlighted: {
+      enum: TruthyEnum.filter((value) => typeof value === "string"),
+      description: "Only highlighted events",
     },
     owner: {
       enum: TruthyEnum.filter((value) => typeof value === "string"),

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -213,6 +213,7 @@ export enum EventListType {
 
 export type EventListParams = {
   list?: EventListType
+  owner?: boolean
   creator?: string
   position?: string
   positions?: string[]
@@ -238,6 +239,7 @@ export type EventListOptions = {
   allow_pending?: boolean
   include_rejected?: boolean
   list?: EventListType
+  owner?: boolean
   user?: string
   creator?: string
   x?: number

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -208,11 +208,11 @@ export enum EventListType {
   Live = "live",
   Upcoming = "upcoming",
   Relevance = "relevance",
-  Highlight = "highlight",
 }
 
 export type EventListParams = {
   list?: EventListType
+  highlighted?: boolean
   owner?: boolean
   creator?: string
   position?: string
@@ -239,6 +239,7 @@ export type EventListOptions = {
   allow_pending?: boolean
   include_rejected?: boolean
   list?: EventListType
+  highlighted?: boolean
   owner?: boolean
   user?: string
   creator?: string

--- a/test/integration/getEventListOwner.test.ts
+++ b/test/integration/getEventListOwner.test.ts
@@ -1,0 +1,308 @@
+import { AuthIdentity } from "@dcl/crypto/dist/types"
+import supertest from "supertest"
+
+import { signedHeaderFactory } from "decentraland-crypto-fetch"
+
+import { DeprecatedEventAttributes } from "../../src/entities/Event/types"
+import { seedEvent } from "../mocks/event"
+import { createIdentity } from "../mocks/identity"
+import { cleanTables, closeTestDb, initTestDb } from "../setup/db"
+import { createTestApp } from "../setup/server"
+
+jest.mock("decentraland-gatsby/dist/utils/api/API", () => {
+  class MockAPI {
+    static catch = () => Promise.resolve(null)
+  }
+  return MockAPI
+})
+
+const mockGetProfiles = jest.fn().mockResolvedValue([])
+jest.mock("decentraland-gatsby/dist/utils/api/Catalyst", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({ getProfiles: mockGetProfiles }),
+  },
+}))
+
+jest.mock("decentraland-gatsby/dist/utils/api/Land", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getTile: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../../src/api/Places", () => ({
+  __esModule: true,
+  default: {
+    get: () => ({
+      getPlaceByPosition: () => Promise.resolve(null),
+      getWorldByName: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../../src/api/Communities", () => ({
+  __esModule: true,
+  default: {
+    get: () => ({
+      getCommunitiesWithToken: () => Promise.resolve([]),
+      getCommunityMembers: () => Promise.resolve([]),
+      getCommunity: () => Promise.resolve(null),
+    }),
+  },
+}))
+
+jest.mock("../../src/entities/Notifications", () => ({
+  sendEventCreated: jest.fn(),
+  sendEventStarted: jest.fn(),
+  sendEventStartsSoon: jest.fn(),
+  sendEventEnded: jest.fn(),
+}))
+
+jest.mock("../../src/entities/Slack/utils", () => ({
+  notifyApprovedEvent: jest.fn(),
+  notifyEditedEvent: jest.fn(),
+  notifyRejectedEvent: jest.fn(),
+}))
+
+const app = createTestApp()
+
+function signedGet(identity: AuthIdentity, path: string) {
+  // The auth middleware validates signatures against `req.baseUrl + req.path`,
+  // which excludes the query string. Sign only the pathname to match.
+  const url = new URL(path, "http://localhost")
+  const createHeaders = signedHeaderFactory()
+  const headers = createHeaders(identity, "GET", url.pathname, {})
+
+  const headerObj: Record<string, string> = {}
+  headers.forEach((value: string, key: string) => {
+    headerObj[key] = value
+  })
+
+  return supertest(app).get(path).set(headerObj)
+}
+
+describe("GET /api/events?owner=true", () => {
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+    jest.clearAllMocks()
+  })
+
+  describe("when the request has no authentication", () => {
+    it("should respond with 401 Unauthorized", async () => {
+      const response = await supertest(app).get("/api/events?owner=true")
+
+      expect(response.status).toBe(401)
+    })
+
+    it("should not leak events in the response body", async () => {
+      const owner = await createIdentity()
+      await seedEvent({ user: owner.address, approved: true })
+
+      const response = await supertest(app).get("/api/events?owner=true")
+
+      expect(response.status).toBe(401)
+      expect(response.body.data).toBeUndefined()
+    })
+  })
+
+  describe("when the request is authenticated", () => {
+    let ownerIdentity: AuthIdentity
+    let ownerAddress: string
+
+    beforeEach(async () => {
+      const owner = await createIdentity()
+      ownerIdentity = owner.identity
+      ownerAddress = owner.address
+    })
+
+    describe("and the user has events in every status", () => {
+      let approvedEvent: DeprecatedEventAttributes
+      let pendingEvent: DeprecatedEventAttributes
+      let rejectedEvent: DeprecatedEventAttributes
+      let otherUserEvent: DeprecatedEventAttributes
+
+      beforeEach(async () => {
+        approvedEvent = await seedEvent({
+          user: ownerAddress,
+          name: "Approved Event",
+          approved: true,
+          rejected: false,
+        })
+        pendingEvent = await seedEvent({
+          user: ownerAddress,
+          name: "Pending Event",
+          approved: false,
+          rejected: false,
+        })
+        rejectedEvent = await seedEvent({
+          user: ownerAddress,
+          name: "Rejected Event",
+          approved: false,
+          rejected: true,
+        })
+
+        const otherUser = await createIdentity()
+        otherUserEvent = await seedEvent({
+          user: otherUser.address,
+          name: "Other User Event",
+          approved: true,
+          rejected: false,
+        })
+      })
+
+      it("should return every event authored by the caller", async () => {
+        const response = await signedGet(
+          ownerIdentity,
+          "/api/events?owner=true"
+        )
+
+        expect(response.status).toBe(200)
+        const ids = response.body.data.map(
+          (event: DeprecatedEventAttributes) => event.id
+        )
+        expect(ids).toEqual(
+          expect.arrayContaining([
+            approvedEvent.id,
+            pendingEvent.id,
+            rejectedEvent.id,
+          ])
+        )
+        expect(ids).toHaveLength(3)
+      })
+
+      it("should include rejected events with rejected=true", async () => {
+        const response = await signedGet(
+          ownerIdentity,
+          "/api/events?owner=true"
+        )
+
+        const rejected = response.body.data.find(
+          (event: DeprecatedEventAttributes) => event.id === rejectedEvent.id
+        )
+        expect(rejected).toBeDefined()
+        expect(rejected.rejected).toBe(true)
+      })
+
+      it("should not include events authored by other users", async () => {
+        const response = await signedGet(
+          ownerIdentity,
+          "/api/events?owner=true"
+        )
+
+        const ids = response.body.data.map(
+          (event: DeprecatedEventAttributes) => event.id
+        )
+        expect(ids).not.toContain(otherUserEvent.id)
+      })
+    })
+
+    describe("and the caller passes a creator filter with a different address", () => {
+      let callerApprovedEvent: DeprecatedEventAttributes
+      let otherCreatorAddress: string
+
+      beforeEach(async () => {
+        callerApprovedEvent = await seedEvent({
+          user: ownerAddress,
+          approved: true,
+        })
+        const otherCreator = await createIdentity()
+        otherCreatorAddress = otherCreator.address
+        await seedEvent({ user: otherCreatorAddress, approved: true })
+      })
+
+      it("should ignore the creator param and return only the caller's events", async () => {
+        const response = await signedGet(
+          ownerIdentity,
+          `/api/events?owner=true&creator=${otherCreatorAddress}`
+        )
+
+        expect(response.status).toBe(200)
+        const ids = response.body.data.map(
+          (event: DeprecatedEventAttributes) => event.id
+        )
+        expect(ids).toEqual([callerApprovedEvent.id])
+      })
+    })
+
+    describe("and the caller filters by a date range", () => {
+      let insideRange: DeprecatedEventAttributes
+      let outsideRange: DeprecatedEventAttributes
+
+      beforeEach(async () => {
+        insideRange = await seedEvent({
+          user: ownerAddress,
+          name: "Inside",
+          start_at: new Date("2030-06-15T10:00:00Z"),
+          finish_at: new Date("2030-06-15T11:00:00Z"),
+          next_start_at: new Date("2030-06-15T10:00:00Z"),
+          next_finish_at: new Date("2030-06-15T11:00:00Z"),
+          approved: false,
+          rejected: true,
+        })
+        outsideRange = await seedEvent({
+          user: ownerAddress,
+          name: "Outside",
+          start_at: new Date("2031-06-15T10:00:00Z"),
+          finish_at: new Date("2031-06-15T11:00:00Z"),
+          next_start_at: new Date("2031-06-15T10:00:00Z"),
+          next_finish_at: new Date("2031-06-15T11:00:00Z"),
+          approved: true,
+          rejected: false,
+        })
+      })
+
+      it("should only return events within the range", async () => {
+        const from = "2030-06-01T00:00:00Z"
+        const to = "2030-07-01T00:00:00Z"
+        const response = await signedGet(
+          ownerIdentity,
+          `/api/events?owner=true&from=${encodeURIComponent(
+            from
+          )}&to=${encodeURIComponent(to)}`
+        )
+
+        expect(response.status).toBe(200)
+        const ids = response.body.data.map(
+          (event: DeprecatedEventAttributes) => event.id
+        )
+        expect(ids).toEqual([insideRange.id])
+        expect(ids).not.toContain(outsideRange.id)
+      })
+    })
+
+    describe("and the caller has no events", () => {
+      it("should return an empty array", async () => {
+        const other = await createIdentity()
+        await seedEvent({ user: other.address, approved: true })
+
+        const response = await signedGet(
+          ownerIdentity,
+          "/api/events?owner=true"
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.body.data).toEqual([])
+      })
+    })
+  })
+
+  describe("when the query uses an unsupported list value", () => {
+    it("should respond with 400 Bad Request", async () => {
+      const { identity } = await createIdentity()
+      const response = await signedGet(identity, "/api/events?list=foo")
+
+      expect(response.status).toBe(400)
+    })
+  })
+})


### PR DESCRIPTION
Adds a new `list=mine` value to `GET /api/events` that returns **every** event authored by the authenticated caller, across all statuses (approved, pending and rejected). Enables the landing-site *My Experiences* tab to render rejected events alongside approved and pending ones with their correct status chip.

### Semantics

- Requires signed-fetch authentication. Unauthenticated callers receive `401`.
- Filters by `lower(e.user) = <auth_address>` — the creator is taken from the identity, never from query params.
- Skips the default `rejected IS FALSE` guard and the `approved IS TRUE` public-listing filter, so the owner sees all their events regardless of moderation state.
- Ignores the `creator` query param when `list=mine` (the address is implicit in the identity).
- Respects every other filter already supported by the endpoint (`from`, `to`, `order`, `limit`, `offset`, `world`, `search`, `position`, `schedule`, `places_ids`, `community_id`, `world_names`).

### Changes

- `src/entities/Event/types.ts` — extends `EventListType` with `Mine = "mine"`.
- `src/entities/Event/schemas.ts` — adds `"mine"` to the AJV `list` enum via `oneOf`.
- `src/entities/Event/routes/getEventList.ts` — throws `RequestError.Unauthorized` when `list=mine` without auth; drops the `creator` param under the same condition.
- `src/entities/Event/model.ts` — `buildEventFilterConditions()` switches its base predicate to `lower(e.user) = <auth_address>` for `Mine`, and skips the `approved` / `creator` clauses so every status is returned.
- `test/integration/getEventListMine.test.ts` — 9 integration tests covering: no-auth 401, owner sees approved/pending/rejected, other users excluded, `creator=<other>` ignored, `from`/`to` honored, empty result, invalid list rejected.
- `docs/openapi.yaml` — documents the new filter, its auth requirement and the `401` response.

### Verification

- `npm test` — 130/130 unit tests pass.
- `npm run test:integration` — 33/33 integration tests pass (24 pre-existing + 9 new).
- `npm run build:server` — 0 type errors.
- `npm run lint` — 0 errors, 25 pre-existing warnings.

### Rollout

1. Merge and deploy to `events.decentraland.zone` (dev).
2. Verify from the landing-site PR against `.zone`.
3. Promote to `events.decentraland.org` (prod).

Landing-site changes are queued on a separate PR and will switch the `isMyTab` query to `list=mine`, drop the `creator` param and remove the admin-events merge hack once this lands on `.zone`.