### PR TITLE
fix: allow decentraland.systems origins in CORS allowlist

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -53,7 +53,7 @@ app.use("/api", [
   withCors({
     corsOrigin: [
       /^http:\/\/localhost:[0-9]{1,10}$/,
-      /^https:\/\/(.{1,50}\.)?decentraland\.(zone|today|org)$/,
+      /^https:\/\/(.{1,50}\.)?decentraland\.(zone|today|org|systems)$/,
       /https:\/\/([a-zA-Z0-9\-_])+-decentraland1\.vercel\.app/,
       "https://mvfw.org",
       "https://dcl-metrics.com",
@@ -85,7 +85,7 @@ app.use("/events", [
   withCors({
     corsOrigin: [
       /^http:\/\/localhost:[0-9]{1,10}$/,
-      /^https:\/\/(.{1,50}\.)?decentraland\.(zone|today|org)$/,
+      /^https:\/\/(.{1,50}\.)?decentraland\.(zone|today|org|systems)$/,
       /https:\/\/([a-zA-Z0-9\-_])+-decentraland1\.vercel\.app/,
       "https://mvfw.org",
       "https://dcl-metrics.com",


### PR DESCRIPTION
The Moderation Center site is hosted at  decentraland.systems. The current allowlist regex only matches the .org / .zone / .today TLDs, so requests from .systems get rejected by CORS preflight.

Adds 'systems' to both /api and /events CORS regexes.