### PR TITLE
fix: auto-correct world flag when coordinates are in Genesis City

### DIFF
--- a/src/entities/Event/routes/createEvent.ts
+++ b/src/entities/Event/routes/createEvent.ts
@@ -92,6 +92,12 @@ export async function createEvent(req: WithAuthProfile<WithAuth>) {
     )
   }
 
+  // Auto-correct the world flag: if coordinates are within Genesis City
+  // and no world server name is provided, this is a Genesis City event.
+  if (data.world && isInsideWorldLimits(x, y) && !data.server) {
+    data.world = false
+  }
+
   // Reject rules whose expansion from `start_at` to `now` would burn
   // excessive CPU inside rrule. The schema already bounds frequency,
   // interval, and count; this catches combinations that slip through

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -285,6 +285,12 @@ export async function updateEventWithOptions(
     )
   }
 
+  // Auto-correct the world flag: if coordinates are within Genesis City
+  // and no world server name is provided, this is a Genesis City event.
+  if (updatedAttributes.world && isInsideWorldLimits(x, y) && !updatedAttributes.server) {
+    updatedAttributes.world = false
+  }
+
   /**
    * Verify categories actually exist
    */


### PR DESCRIPTION
## Summary

- Auto-corrects `world` to `false` on event create and update when coordinates are within Genesis City limits and no world `server` name is provided
- Prevents events with valid Genesis City coordinates from being incorrectly flagged as World events

## Problem

Events with valid Genesis City coordinates (e.g. -77, 77) can end up with `world: true`, causing them to be filtered out of the /whats-on page which queries `world=false`. This makes the event invisible on the website while still appearing in the Unity client (which doesn't filter by world).

Real-world example: the recurring event "W.T.F. - We Talk Facts DCL" (id: `b6b57b29-b416-48b5-aa2f-1fcd6f6eab1d`) is hosted at coordinates (-77, 77) in Genesis City but has `world: true`, so it doesn't appear on the /whats-on page despite being approved and trending.

The `world` boolean is entirely user-submitted with no server-side validation. The new event submission form at `/whats-on/new-hangout` correctly derives the `world` field from the location toggle on fresh submissions, but if an event was originally created as a World event and later had its location changed, or if the field was set incorrectly for any reason, there is no backend safeguard to correct it.

## Fix

Added a check in both `createEvent.ts` and `updateEvent.ts` that runs after the existing `isInsideWorldLimits` validation:

```typescript
if (data.world && isInsideWorldLimits(x, y) && !data.server) {
  data.world = false
}
```

If an event has `world: true` but its coordinates are valid Genesis City coordinates and no world server name is provided, `world` is auto-corrected to `false`.

## Note

This fix only applies to events created or updated going forward. Existing miscategorized events (like the one above) would need a one-time database update or re-save to be corrected.

## Test plan

- [ ] Create an event with `world: true`, valid Genesis City coordinates, and no `server` — verify `world` is saved as `false`
- [ ] Create an event with `world: true` and a valid `server` name — verify `world` remains `true`
- [ ] Update an existing event to `world: true` with Genesis City coordinates and no `server` — verify `world` is corrected to `false`
- [ ] Verify normal Genesis City and World event creation still works as expected