### PR TITLE
fix: bump max_event_recurrent so the slide window covers calendar navigation

### DIFF
--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -95,7 +95,11 @@ export enum Position {
   LAST = -1,
 }
 
-export const MAX_EVENT_RECURRENT = 10
+// Caps how many future occurrences `futureRecurrentDates` materializes into
+// `recurrent_dates`. 10 was set in 2021 (c65aa62) for a list-based UI; the
+// new calendar lets users navigate weeks ahead, so 10 ran out visibly.
+// 1000 matches the JSON schema bound on `recurrent_count`.
+export const MAX_EVENT_RECURRENT = 1000
 
 export const MAX_REJECTION_REASON_LENGTH = 500
 export const MAX_ADMIN_ACTOR_LENGTH = 42

--- a/src/entities/Event/utils.test.ts
+++ b/src/entities/Event/utils.test.ts
@@ -104,6 +104,28 @@ describe("futureRecurrentDates", () => {
     })
   })
 
+  describe("when the recurrence is WEEKLY and recurrent_until is years away", () => {
+    // Regression for the symptom reported as "recurring hangouts disappear
+    // from /whats-on around late July": the old MAX_EVENT_RECURRENT cap of
+    // 10 meant that a weekly event created in early May only had ~10
+    // future dates persisted (≈10 weeks ahead), so the sites calendar
+    // showed nothing past late July even though the rule was set to
+    // recur for years. Asserts that the window now reaches at least six
+    // months into the future for a typical weekly cadence.
+    it("should populate enough future dates to cover several months of calendar navigation", () => {
+      const dates = futureRecurrentDates({
+        ...baseRecurrence,
+        start_at: new Date(),
+        recurrent_frequency: Frequency.WEEKLY,
+        recurrent_until: new Date(Date.now() + 5 * 365 * 24 * 60 * 60 * 1000),
+      })
+
+      // 26 weeks ≈ 6 months — comfortably more than the legacy "10"
+      // produced (≈2.3 months for weekly).
+      expect(dates.length).toBeGreaterThan(26)
+    })
+  })
+
   describe("when start_at is years in the past with an absurdly large recurrent_count", () => {
     it("should not allocate past dates and should return MAX_EVENT_RECURRENT future dates", () => {
       const options = {


### PR DESCRIPTION
## Summary

Fixes the user-reported symptom "recurring hangouts disappear from `decentraland.org/whats-on` around late July, even though no July end date was set."

Bumps `MAX_EVENT_RECURRENT` from `10` to `1000`. The constant caps how many future occurrences `futureRecurrentDates` materializes into `recurrent_dates` for each event. Ten was set in 2021 (`c65aa62`) when the UI was a list ordered by `next_start_at`; the new sites calendar lets users navigate weeks ahead, which exposes the cap as a visible cliff.

## Reproduction

1. Today is **2026-05-18**. Submit a weekly event: `start_at = 2026-05-19`, `recurrent_until = 2027-05-19`, no `recurrent_count`.
2. Fetch the event from the events API. `recurrent_dates` has 10 entries ending ~`2026-07-21`. `finish_at` matches.
3. Open `/whats-on` and click ▶ until the calendar shows the week of **2026-08-04**. The event isn't there — even though the recurrence rule extends a full year forward.

## What was happening (and why nobody complained for 5 years)

The cron is doing its job. After each occurrence ends, `updateNextStartAt` re-runs `calculateRecurrentProperties` and slides the 10-date window forward by one. So week to week:

| `recurrent_dates` last entry | finish_at |
| --- | --- |
| Day 0 (creation) | Jul 11 |
| Day 8 (after May 16 occurrence ends) | Jul 18 |
| Day 15 | Jul 25 |
| Day 22 | Aug 1 |

The window slides perpetually; it's not a permanent cutoff. **The bug from the user's point of view is that the window today only reaches ~10 weeks ahead.** Anyone navigating the calendar further into the future sees empty cells and concludes the events ended.

This was invisible for years because the legacy `events.decentraland.org` UI showed a list of "Upcoming events" ordered by `next_start_at` — users never asked the page to render August in May. The sites calendar (absorbed 2026-04-17) is the first UI that exposes the window as something the user can outrun.

(There are 8 events in prod with `recurrent_count = 10` set explicitly. Those are a different problem — RRule honors `count` over `until`, so the cron can't extend them. They need an operator-side review to null `recurrent_count` where the creator clearly meant "until X"; out of scope for this PR.)

## Fix

`types.ts`:

```diff
-export const MAX_EVENT_RECURRENT = 10
+export const MAX_EVENT_RECURRENT = 1000
```

`1000` matches the JSON schema bound the same file already enforces on `recurrent_count`. Coverage per frequency at the new cap:

| Frequency | Coverage |
| --- | --- |
| WEEKLY (100 / 144 prod events) | ~19 years |
| DAILY (27 / 144) | ~2.7 years |
| MONTHLY (17 / 144) | ~83 years |
| HOURLY (0 / 144) | ~41 days |

In every common case `recurrent_until` will end the iteration long before the count cap fires. The cap is now a safety net, not the active bound.

Storage worst case per event: `~1000 × 30 bytes ≈ 30 KB`. At current volume (~150 recurrent events) total `recurrent_dates` footprint stays in single-digit MB.

CPU is bounded by the existing `MAX_RECURRENT_PAST_ITERATIONS = 50000` guard in `createEvent`/`updateEvent`/`updateNextStartAt`, so the bump doesn't open new DoS surface.

## Operational follow-up (after deploy)

This PR only changes what new materializations produce. Events whose `recurrent_dates` was last written before the deploy continue to carry the legacy 10-entry window until the next cron tick that picks them up — and the cron only picks up rows where `next_start_at + duration < now()`. So an event with `next_start_at` two weeks in the future stays at the old window for two more weeks.

A one-shot script that re-runs `calculateRecurrentProperties` + `calculateNextRecurrentDates` for every recurrent event will close the gap immediately. Sketch:

```ts
const rows = await EventModel.query<EventAttributes>(`
  SELECT * FROM events
  WHERE rejected IS FALSE
    AND recurrent IS TRUE
    AND finish_at < recurrent_until - INTERVAL '30 days'
`)
for (const event of rows) {
  const built = EventModel.build(event)!
  await EventModel.update(
    { ...calculateRecurrentProperties(built), ...calculateNextRecurrentDates(built) },
    { id: event.id },
  )
}
```

Run on stg, then prod. Pause the `@eachMinute` cron during the run or rely on row-level locks. Skip the script if you're fine with the gradual transition over the next ~10 weeks.

## Test plan

- [x] `npx jest --testPathPattern="entities/Event/utils.test"` — 20 / 20 passing (includes new regression "should populate enough future dates to cover several months of calendar navigation").
- [x] `npx jest --testPathPattern="entities/Event/(cron|model|schemas).test"` — 51 / 51 passing.
- [ ] After deploy: navigate `decentraland.org/whats-on` to weeks of August-October 2026; events created recently should now extend that far.
