### PR TITLE
feat: accept webp images on poster endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1099,7 +1099,7 @@ paths:
       summary: Upload event poster image
       description: |
         Uploads an event poster image to AWS S3 and returns the public URL.
-        Maximum file size: 500KB. Supported formats: JPEG, PNG, GIF.
+        Maximum file size: 500KB. Supported formats: JPEG, PNG, GIF, WebP.
       operationId: uploadPoster
       security: []
       requestBody:
@@ -1114,7 +1114,7 @@ paths:
                 poster:
                   type: string
                   format: binary
-                  description: Image file (JPEG, PNG, or GIF, max 500KB)
+                  description: Image file (JPEG, PNG, GIF, or WebP, max 500KB)
       responses:
         "200":
           description: Image uploaded successfully
@@ -1156,7 +1156,7 @@ paths:
         Uploads a vertical event poster image to AWS S3 and returns the public URL.
         This endpoint is specifically for portrait-oriented images.
 
-        **Format:** PNG or JPG only (no GIF)
+        **Format:** PNG, JPG or WebP only (no GIF)
         **Recommended size:** 716 x 1814 pixels
         **Max weight:** 500 KB
       operationId: uploadPosterVertical
@@ -1173,7 +1173,7 @@ paths:
                 poster:
                   type: string
                   format: binary
-                  description: Vertical image file (PNG or JPG only, max 500KB, recommended 716x1814 pixels)
+                  description: Vertical image file (PNG, JPG or WebP only, max 500KB, recommended 716x1814 pixels)
       responses:
         "200":
           description: Vertical image uploaded successfully
@@ -1188,7 +1188,7 @@ paths:
                   data:
                     $ref: "#/components/schemas/Poster"
         "400":
-          description: Bad request (invalid file type - only PNG and JPG allowed)
+          description: Bad request (invalid file type - only PNG, JPG and WebP allowed)
           content:
             application/json:
               schema:
@@ -2220,7 +2220,7 @@ components:
         type:
           type: string
           description: MIME type
-          enum: [image/jpeg, image/png, image/gif]
+          enum: [image/jpeg, image/png, image/gif, image/webp]
           example: "image/jpeg"
       required:
         - filename

--- a/src/entities/Poster/routes.ts
+++ b/src/entities/Poster/routes.ts
@@ -176,10 +176,10 @@ export async function uploadPosterVertical(
   }
 
   const [type] = poster.mimetype.split(";")
-  // Only allow PNG and JPG for vertical posters (no GIF)
+  // Only allow PNG, JPG and WebP for vertical posters (no GIF)
   if (!POSTER_VERTICAL_FILE_TYPES.includes(type)) {
     throw new RequestError(
-      `Invalid file type ${type}. Only PNG and JPG are allowed for vertical posters`,
+      `Invalid file type ${type}. Only PNG, JPG and WebP are allowed for vertical posters`,
       RequestError.BadRequest
     )
   }

--- a/src/entities/Poster/types.test.ts
+++ b/src/entities/Poster/types.test.ts
@@ -1,0 +1,37 @@
+import {
+  POSTER_FILE_TYPES,
+  POSTER_VERTICAL_FILE_TYPES,
+  extension,
+} from "./types"
+
+describe("POSTER_FILE_TYPES", () => {
+  it("accepts webp", () => {
+    expect(POSTER_FILE_TYPES).toContain("image/webp")
+  })
+})
+
+describe("POSTER_VERTICAL_FILE_TYPES", () => {
+  it("accepts webp", () => {
+    expect(POSTER_VERTICAL_FILE_TYPES).toContain("image/webp")
+  })
+
+  it("does not accept gif", () => {
+    expect(POSTER_VERTICAL_FILE_TYPES).not.toContain("image/gif")
+  })
+})
+
+describe("extension", () => {
+  it("maps webp to .webp", () => {
+    expect(extension("image/webp")).toBe(".webp")
+  })
+
+  it("maps the other supported types to their extension", () => {
+    expect(extension("image/jpeg")).toBe(".jpg")
+    expect(extension("image/png")).toBe(".png")
+    expect(extension("image/gif")).toBe(".gif")
+  })
+
+  it("returns an empty string for unsupported types", () => {
+    expect(extension("image/svg+xml")).toBe("")
+  })
+})

--- a/src/entities/Poster/types.ts
+++ b/src/entities/Poster/types.ts
@@ -1,8 +1,17 @@
-export const POSTER_FILE_TYPES = ["image/jpeg", "image/png", "image/gif"]
+export const POSTER_FILE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]
 export const POSTER_FILE_SIZE = 500 * 1024
 
 // Vertical poster specific validations
-export const POSTER_VERTICAL_FILE_TYPES = ["image/jpeg", "image/png"]
+export const POSTER_VERTICAL_FILE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]
 export const POSTER_VERTICAL_FILE_SIZE = 500 * 1024 // 500 KB
 export const POSTER_VERTICAL_RECOMMENDED_WIDTH = 716
 export const POSTER_VERTICAL_RECOMMENDED_HEIGHT = 1814
@@ -24,6 +33,9 @@ export function extension(type: string) {
 
     case "image/jpeg":
       return ".jpg"
+
+    case "image/webp":
+      return ".webp"
 
     default:
       return ""


### PR DESCRIPTION
Adds WebP (`image/webp`) to the accepted upload formats for both poster endpoints.

- `/poster`: now accepts JPEG, PNG, GIF and WebP.
- `/poster-vertical`: now accepts JPEG, PNG and WebP (GIF still rejected).
- `extension()` maps `image/webp` to `.webp` so uploaded files keep a correct extension in S3.
- OpenAPI docs updated (endpoint descriptions and `Poster.type` enum).

Verified with `npm run format`, `npm run lint`, `npm run build` and a new unit test covering the type lists and the extension mapping (`npm test`).
