### PR TITLE
fix: name database query metrics to bound query-label cardinality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,12 @@ For any change that touches an enum or filter (e.g. `EventListType`):
 4. `src/entities/<Entity>/routes/*.ts` (handlers)
 5. `docs/openapi.yaml` — every new query param / enum addition needs to be reflected here AND covered in an integration test in the same PR
 
+### DB query metric names (use `namedQuery`, not `query`)
+
+Every raw `Model.query()` / `Model.rowCount()` call must use the named variant — `namedQuery("<name>", sql)` / `namedRowCount("<name>", sql)` — so the Prometheus `query` label stays bounded. The deprecated `query()`/`rowCount()` label the `database_duration_seconds` metric by a SHA1 of the SQL text; dynamically-built SQL (variable `IN (...)` lists, `SQL.raw()` interpolation, conditional clauses) then produces a new hash per shape and explodes cardinality. The structured methods (`find`, `update`, `count`, …) already emit bounded labels and need no change.
+
+Naming convention: prefix with the table, singular verb for single-record mutations (`event_create`, `event_update`), plural for list/aggregate reads (`events_list`, `events_count_filtered`, `events_starting_in_range`). One stable name per logical query, regardless of how many conditional SQL shapes it builds.
+
 ### Hidden backend deps inside frontend-looking dirs
 
 These look like frontend things but the API depends on them — never delete blindly:

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -301,7 +301,10 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     `
 
     return EventModel.buildAll(
-      await EventModel.namedQuery<EventAttributes>("events_starting_in_range", query)
+      await EventModel.namedQuery<EventAttributes>(
+        "events_starting_in_range",
+        query
+      )
     )
   }
 
@@ -351,7 +354,10 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     `
 
     return EventModel.buildAll(
-      await EventModel.namedQuery<EventAttributes>("events_recurrent_finished", query)
+      await EventModel.namedQuery<EventAttributes>(
+        "events_recurrent_finished",
+        query
+      )
     )
   }
 
@@ -421,7 +427,10 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         ${join(conditions, SQL` `)}
     `
 
-    const result = await EventModel.namedQuery<{ count: string }>("events_count_filtered", query)
+    const result = await EventModel.namedQuery<{ count: string }>(
+      "events_count_filtered",
+      query
+    )
     return parseInt(result[0]?.count || "0", 10)
   }
 
@@ -431,14 +440,17 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     }
 
     return EventModel.buildAll(
-      await EventModel.namedQuery<DeprecatedEventAttributes>("events_attending", SQL`
+      await EventModel.namedQuery<DeprecatedEventAttributes>(
+        "events_attending",
+        SQL`
       SELECT e.*, a.user is not null as attending
       FROM ${table(EventModel)} e
       LEFT JOIN ${table(
         EventAttendee
       )} a on e.id = a.event_id AND a.user = ${user}
       WHERE e.finish_at > now() AND e.rejected IS FALSE
-    `)
+    `
+      )
     )
   }
 

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -54,7 +54,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       VALUES ${objectValues(keys, [event])}
     `
 
-    return this.query(sql) as any
+    return this.namedQuery("event_create", sql) as any
   }
 
   static update<U extends QueryPart = any, P extends QueryPart = any>(
@@ -98,7 +98,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       )}
   `
 
-    return this.query(sql) as any
+    return this.namedQuery("event_update", sql) as any
   }
 
   static selectNextStartAt(
@@ -283,7 +283,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       LIMIT ${SITEMAP_ITEMS_PER_PAGE}
     `
 
-    return await EventModel.query<{ id: string }>(query)
+    return await EventModel.namedQuery<{ id: string }>("events_sitemap", query)
   }
 
   static async getEventsStartingInRange(
@@ -300,7 +300,9 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         AND e.next_start_at < (to_timestamp(${starting_to} / 1000.0))
     `
 
-    return EventModel.buildAll(await EventModel.query<EventAttributes>(query))
+    return EventModel.buildAll(
+      await EventModel.namedQuery<EventAttributes>("events_starting_in_range", query)
+    )
   }
 
   static async getEventsEndingInRangeWithAttendeeCount(
@@ -322,11 +324,11 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       GROUP BY e.id, e.community_id
     `
 
-    const results = await EventModel.query<{
+    const results = await EventModel.namedQuery<{
       id: string
       community_id: string | null
       attendee_count: number
-    }>(query)
+    }>("events_ending_in_range", query)
 
     return results.map((result) => ({
       event: {
@@ -348,7 +350,9 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         AND (e.next_start_at + (e.duration * '1 millisecond'::interval)) < now()
     `
 
-    return EventModel.buildAll(await EventModel.query<EventAttributes>(query))
+    return EventModel.buildAll(
+      await EventModel.namedQuery<EventAttributes>("events_recurrent_finished", query)
+    )
   }
 
   static async getEvents(options: Partial<EventListOptions> = {}) {
@@ -390,7 +394,9 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
       ${offset(options.offset)}
     `
 
-    return EventModel.buildAll(await EventModel.query<EventAttributes>(query))
+    return EventModel.buildAll(
+      await EventModel.namedQuery<EventAttributes>("events_list", query)
+    )
   }
 
   static async countEventsWithFilter(options: Partial<EventListOptions> = {}) {
@@ -415,7 +421,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         ${join(conditions, SQL` `)}
     `
 
-    const result = await EventModel.query<{ count: string }>(query)
+    const result = await EventModel.namedQuery<{ count: string }>("events_count_filtered", query)
     return parseInt(result[0]?.count || "0", 10)
   }
 
@@ -425,7 +431,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     }
 
     return EventModel.buildAll(
-      await EventModel.query<DeprecatedEventAttributes>(SQL`
+      await EventModel.namedQuery<DeprecatedEventAttributes>("events_attending", SQL`
       SELECT e.*, a.user is not null as attending
       FROM ${table(EventModel)} e
       LEFT JOIN ${table(

--- a/src/entities/EventAttendee/model.ts
+++ b/src/entities/EventAttendee/model.ts
@@ -33,7 +33,10 @@ export default class EventAttendeeModel extends Model<EventAttendeeAttributes> {
       ${offset(options.offset)}
     `
 
-    return EventAttendeeModel.query<EventAttendeeAttributes>(query)
+    return EventAttendeeModel.namedQuery<EventAttendeeAttributes>(
+      "event_attendees_list_by_event",
+      query
+    )
   }
 
   static async latest(eventId: string) {

--- a/src/entities/EventCategory/model.ts
+++ b/src/entities/EventCategory/model.ts
@@ -15,10 +15,9 @@ export default class EventCategoryModel extends Model<EventCategoryAttributes> {
     const query = SQL`SELECT count(*) FROM ${table(
       EventCategoryModel
     )} WHERE "name" IN ${values(categories)}`
-    const categoriesFound = await EventCategoryModel.namedQuery<{ count: number }>(
-      "event_categories_validate_count",
-      query
-    )
+    const categoriesFound = await EventCategoryModel.namedQuery<{
+      count: number
+    }>("event_categories_validate_count", query)
 
     return categoriesFound[0].count == categories.length
   }

--- a/src/entities/EventCategory/model.ts
+++ b/src/entities/EventCategory/model.ts
@@ -15,7 +15,8 @@ export default class EventCategoryModel extends Model<EventCategoryAttributes> {
     const query = SQL`SELECT count(*) FROM ${table(
       EventCategoryModel
     )} WHERE "name" IN ${values(categories)}`
-    const categoriesFound = await EventCategoryModel.query<{ count: number }>(
+    const categoriesFound = await EventCategoryModel.namedQuery<{ count: number }>(
+      "event_categories_validate_count",
       query
     )
 

--- a/src/entities/ProfileSettings/model.ts
+++ b/src/entities/ProfileSettings/model.ts
@@ -38,7 +38,10 @@ export default class ProfileSettingsModel extends Model<ProfileSettingsAttribute
     const query = SQL`SELECT * FROM ${table(
       ProfileSettingsModel
     )} WHERE "user" IN ${values(users)}`
-    return this.query<ProfileSettingsAttributes>(query)
+    return this.namedQuery<ProfileSettingsAttributes>(
+      "profile_settings_find_by_users",
+      query
+    )
   }
 
   static async list() {
@@ -47,7 +50,10 @@ export default class ProfileSettingsModel extends Model<ProfileSettingsAttribute
       FROM ${table(this)}
       WHERE "permissions" > array[]::varchar[]
     `
-    return this.query<ProfileSettingsAttributes>(query)
+    return this.namedQuery<ProfileSettingsAttributes>(
+      "profile_settings_list",
+      query
+    )
   }
 
   /** @deprecated Notification no longer used */

--- a/src/entities/ProfileSubscription/model.ts
+++ b/src/entities/ProfileSubscription/model.ts
@@ -23,7 +23,10 @@ export default class ProfileSubscriptionModel extends Model<ProfileSubscriptionA
     const query = SQL`DELETE FROM ${table(
       ProfileSubscriptionModel
     )} WHERE "endpoint" IN ${values(endpoints)}`
-    return this.query<ProfileSubscriptionAttributes>(query)
+    return this.namedQuery<ProfileSubscriptionAttributes>(
+      "profile_subscriptions_delete_all",
+      query
+    )
   }
 
   static async findByUsers(users: string[]) {
@@ -34,7 +37,10 @@ export default class ProfileSubscriptionModel extends Model<ProfileSubscriptionA
     const query = SQL`SELECT * FROM ${table(
       ProfileSubscriptionModel
     )} WHERE "user" IN ${values(users)}`
-    return this.query<ProfileSubscriptionAttributes>(query)
+    return this.namedQuery<ProfileSubscriptionAttributes>(
+      "profile_subscriptions_find_by_users",
+      query
+    )
   }
 
   static async findByUser(user: string) {


### PR DESCRIPTION
- Replaces the deprecated Model.query() hash-label path (SHA1 of dynamic SQL → ~2,600 distinct events_<hash> series, ~30% of PRD Prometheus) with namedQuery("<name>", …) at all 15 call sites, collapsing each query to one stable, readable label.
- No behavior change; build + 138 unit tests pass.