### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine as compiler
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as compiler
 
 RUN apk add --no-cache openssh-client \
  && mkdir ~/.ssh && ssh-keyscan github.com > ~/.ssh/known_hosts
@@ -32,7 +32,7 @@ COPY ./tsconfig.json        /app/tsconfig.json
 RUN npm run build
 RUN npm prune --production
 
-FROM node:24-alpine
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
 WORKDIR /app
 
 RUN rm -rf \


### PR DESCRIPTION
Sets the base image to `node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995` (was `node:24-alpine`) and pins it to an immutable sha256 digest for reproducible builds.