### PR TITLE
refactor: drop node-fetch in favor of native fetch

### DIFF
--- a/bin/smokeTest.ts
+++ b/bin/smokeTest.ts
@@ -1,5 +1,3 @@
-import fetch from "node-fetch"
-
 type EnvName = "zone" | "prod"
 
 const ENVS: Record<EnvName, string> = {
@@ -313,7 +311,7 @@ async function runOneOnce(env: EnvName, check: Check): Promise<Result> {
   const url = `${baseUrl}${fillPlaceholders(check.path, env)}`
   const started = Date.now()
   try {
-    const init: Parameters<typeof fetch>[1] = {
+    const init: RequestInit = {
       method: check.method ?? "GET",
       headers: {
         accept:
@@ -325,8 +323,8 @@ async function runOneOnce(env: EnvName, check: Check): Promise<Result> {
           : {}),
         ...check.headers,
       },
-      timeout: 30_000,
-    } as never
+      signal: AbortSignal.timeout(30_000),
+    }
     if (check.body !== undefined) {
       init.body =
         typeof check.body === "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "abort-controller": "^3.0.0",
         "apicache": "^1.6.2",
         "aws-sdk": "^2.1002.0",
-        "dcl-catalyst-client": "^21.5.0",
+        "dcl-catalyst-client": "^22.0.0",
         "decentraland-gatsby": "^8.1.0",
         "express-fileupload": "^1.2.1",
         "html-escaper": "^3.0.3",
@@ -4686,6 +4686,14 @@
       "integrity": "sha512-gJZo3IB8U+jhBJWR0DgoLS+zaUDIb/u79e7Rp+MEM78uH3bvC19S3Dd8lxWEbPXNKlCB0saUptfK/Buw0c1y2Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/@dcl/core-commons": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.0.tgz",
+      "integrity": "sha512-lcCgnwxkq/MoTbU59wKnspmVaQyEIP8SRRDUCd3Werrwj+nsH6T7xGuVo17cLVEd8D/Hi3NLFtBiq+N7kZAt/A==",
+      "dependencies": {
+        "@well-known-components/interfaces": "^1.5.2"
+      }
+    },
     "node_modules/@dcl/crypto": {
       "version": "3.4.5",
       "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz",
@@ -5217,6 +5225,14 @@
       "resolved": "https://registry.npmjs.org/@dcl/feature-flags/-/feature-flags-1.2.0.tgz",
       "integrity": "sha512-vzEcc0ieRwD7sMb1fQsN6f99Y7i+j9cZD+93QAZmKrxqrNCR25vY4SJdg+hrkOGx14lEeuaQfpYYuxgY89ewGg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dcl/fetch-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dcl/fetch-component/-/fetch-component-1.0.1.tgz",
+      "integrity": "sha512-OgkOeBtIfxuQ96caFnE+JDORiQEBKajF3DpB7T5ZcoVkbnKGnJ1fmk4eOklzA+Eqt2LOAKsXfKa1RqR9bPwUlg==",
+      "dependencies": {
+        "@dcl/core-commons": "0.10.0"
+      }
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -22561,25 +22577,26 @@
       }
     },
     "node_modules/dcl-catalyst-client": {
-      "version": "21.10.2",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.10.2.tgz",
-      "integrity": "sha512-1WDb/63KAsvGLiyT2F9rimzWfbAXkNTgdIFrnlqqYhCdcNxmI3EeaMdgBbUkuY5sBAZamRajqxk2eFCgysIQnA==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-22.0.0.tgz",
+      "integrity": "sha512-K2cjYR5RZcdH6YNC7YjQMmZd4fhlE7zGyc79sYWvJGgofjO8TxAJ7CCNahqqllzMrdnxidFFGOWXTYJMJmOdqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/catalyst-contracts": "^4.4.0",
         "@dcl/crypto": "^3.4.0",
+        "@dcl/fetch-component": "^1.0.1",
         "@dcl/hashing": "^3.0.0",
-        "@dcl/schemas": "^11.5.0",
-        "@well-known-components/fetch-component": "^2.0.0",
-        "cookie": "^0.5.0",
-        "cross-fetch": "^3.1.5",
-        "form-data": "^4.0.0"
+        "@dcl/schemas": "^23.0.0",
+        "cookie": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/dcl-catalyst-client/node_modules/@dcl/schemas": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
-      "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-23.1.0.tgz",
+      "integrity": "sha512-2+Sp4OrUKyGxEe1nLMuLtEmNwLThGUDei0QqXzurkQMkhQdJvB1viS4UW86Wia7AelmCzBewSLU6to8CgQ8UEw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -24079,6 +24096,34 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "license": "MIT"
+    },
+    "node_modules/decentraland-dapps/node_modules/dcl-catalyst-client": {
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.11.0.tgz",
+      "integrity": "sha512-6BgOCz4aYnMGtuIkXTLP3hjoZHLwoScTLvs73U4R8Um6lIsnKNsbn5UyaocVNpkgrzZWaTGHDsv36OZJNH3XTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/catalyst-contracts": "^4.4.0",
+        "@dcl/crypto": "^3.4.0",
+        "@dcl/hashing": "^3.0.0",
+        "@dcl/schemas": "^23.0.0",
+        "@well-known-components/fetch-component": "^2.0.0",
+        "cookie": "^0.5.0",
+        "cross-fetch": "^3.1.5",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/dcl-catalyst-client/node_modules/@dcl/schemas": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-23.1.0.tgz",
+      "integrity": "sha512-2+Sp4OrUKyGxEe1nLMuLtEmNwLThGUDei0QqXzurkQMkhQdJvB1viS4UW86Wia7AelmCzBewSLU6to8CgQ8UEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
+      }
     },
     "node_modules/decentraland-dapps/node_modules/events": {
       "version": "3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apicache": "^1.6.2",
         "aws-sdk": "^2.1002.0",
         "dcl-catalyst-client": "^22.0.0",
-        "decentraland-gatsby": "^8.1.0",
+        "decentraland-gatsby": "^8.4.5",
         "express-fileupload": "^1.2.1",
         "html-escaper": "^3.0.3",
         "node-pg-migrate": "^6.0.0",
@@ -4695,25 +4695,54 @@
       }
     },
     "node_modules/@dcl/crypto": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz",
-      "integrity": "sha512-uneyjOAOx7pi5kabZsLmPm9kSLkCk4Cok8FUsvT+6k8RquqkjKqocvkGVOMaoWsfU6S3mkLOyaeqEKmOy4ErxA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.7.0.tgz",
+      "integrity": "sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^9.2.0",
+        "@dcl/schemas": "^25.2.0",
         "eth-connect": "^6.0.3",
-        "ethereum-cryptography": "^1.0.3"
+        "ethereum-cryptography": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@dcl/crypto-middleware": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.0.0.tgz",
+      "integrity": "sha512-j12R22lMBYk5zwXRzoKxGvU+F8IER+iV9buehbriHPkxVQdBOBqS0EoWtREpanGW1MLhHqoAijsOft1hXzc/rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/core-commons": "^0.10.0",
+        "@dcl/crypto": "3.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.0.0 || ^5.0.0",
+        "koa": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "koa": {
+          "optional": true
+        }
       }
     },
     "node_modules/@dcl/crypto/node_modules/@dcl/schemas": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
-      "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-25.3.0.tgz",
+      "integrity": "sha512-ChFW3jU3ELN6YsRvs8TZIueBR8/DDxFcWPOeCoPafjLzSRK4GX9wHYrD3Crent07C3i3tm1rX8L/2rw+S39bzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
-        "ajv-keywords": "^5.1.0"
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
       }
     },
     "node_modules/@dcl/eslint-config": {
@@ -5258,6 +5287,30 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@dcl/http-server": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.0.2.tgz",
+      "integrity": "sha512-tzzBrW0JtexwwZNB7yYLiKVhG8LysWf7Sy2xrLBrqF8BAsCWqeLvPqftKrLBHNkxAd66zHsi5P3Mg5I9GdvdRA==",
+      "dependencies": {
+        "@dcl/core-commons": "0.10.1",
+        "@well-known-components/interfaces": "^1.5.1",
+        "destroy": "^1.2.0",
+        "fp-future": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mitt": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "path-to-regexp": "^6.3.0",
+        "reflect-metadata": "^0.2.2"
+      }
+    },
+    "node_modules/@dcl/http-server/node_modules/@dcl/core-commons": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.1.tgz",
+      "integrity": "sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==",
+      "dependencies": {
+        "@well-known-components/interfaces": "^1.5.2"
+      }
+    },
     "node_modules/@dcl/schemas": {
       "version": "26.5.0",
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.5.0.tgz",
@@ -5626,66 +5679,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@ethereumjs/tx/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/tx/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/tx/node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/tx/node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/tx/node_modules/ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
-      }
-    },
     "node_modules/@ethereumjs/util": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
@@ -5698,66 +5691,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@ethereumjs/util/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/util/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/util/node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/util/node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/util/node_modules/ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -9242,18 +9175,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11903,33 +11824,30 @@
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
-      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.2.0",
-        "@noble/secp256k1": "~1.7.0",
-        "@scure/base": "~1.1.0"
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
-      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@scure/bip32/node_modules/@scure/base": {
       "version": "1.1.9",
@@ -11941,32 +11859,17 @@
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
-      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.2.0",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
-      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@scure/bip39/node_modules/@scure/base": {
       "version": "1.1.9",
@@ -14038,16 +13941,6 @@
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.14.tgz",
       "integrity": "sha512-lmPil1g82wwWg/qHSxMWkSKyJGQOK+ejXeMAAWyxNtVUD0/Ycj2maL63RAqpxVfdtvTfZkRnqzB0A9ft59y69g==",
       "license": "MIT"
-    },
-    "node_modules/@types/compression": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
-      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/configstore": {
       "version": "2.1.1",
@@ -18446,35 +18339,6 @@
         "cross-fetch": "^3.1.5"
       }
     },
-    "node_modules/@well-known-components/http-server": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@well-known-components/http-server/-/http-server-1.1.6.tgz",
-      "integrity": "sha512-ufTiLQg1QPrgiDjr3bYuKdevZyLkJONRpmFd922F6Ty+Wd0CCOoZZzyP0vlanr0DvcrTifkO04N33fEuhg0AsQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/compression": "^1.7.0",
-        "@types/cors": "^2.8.9",
-        "@types/http-errors": "^1.8.1",
-        "compression": "^1.7.4",
-        "cors": "^2.8.5",
-        "destroy": "^1.2.0",
-        "express": "^4.18.1",
-        "fp-future": "^1.0.1",
-        "http-errors": "^1.8.1",
-        "node-fetch": "^2.6.7",
-        "on-finished": "^2.4.1",
-        "path-to-regexp": "^6.2.1"
-      },
-      "peerDependencies": {
-        "@well-known-components/interfaces": "^1.0.0"
-      }
-    },
-    "node_modules/@well-known-components/http-server/node_modules/@types/http-errors": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
-      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
-      "license": "MIT"
-    },
     "node_modules/@well-known-components/interfaces": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz",
@@ -20139,26 +20003,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
@@ -24024,17 +23868,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/decentraland-crypto-middleware": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/decentraland-crypto-middleware/-/decentraland-crypto-middleware-1.3.0.tgz",
-      "integrity": "sha512-kfns4TuQy0M3rc+soQqsP6UFY21c1nQ5xNQn9/YVhR9bR12nybaVJgGFVubznMuWNZE2h+MGgl4DQbTnAXfSOA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@dcl/crypto": "^3.4.5",
-        "node-fetch": "^2.7.0",
-        "passport-strategy": "^1.0.0"
-      }
-    },
     "node_modules/decentraland-dapps": {
       "version": "28.9.0",
       "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-28.9.0.tgz",
@@ -24158,15 +23991,18 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.1.0.tgz",
-      "integrity": "sha512-1CBEP6Jx8WslqheH8J5FdLuUfoUxUg7jgjtubhPuJSOeqedatFJmrd4E9TWXYj+O/ICziWJy+7HVc3W46Xs9+Q==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.5.tgz",
+      "integrity": "sha512-qqLEf35cf/1lPdka65dcBoRdqQf5kolSCI1HshqKm7+NYOzlE6Xwi0rLNL0Wvx1C9TragjwUtXhCHYSLfGku8w==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",
+        "@dcl/core-commons": "^0.10.0",
         "@dcl/crypto": "^3.4.3",
+        "@dcl/crypto-middleware": "^4.0.0",
         "@dcl/feature-flags": "^1.2.0",
-        "@dcl/schemas": "^22.5.0",
+        "@dcl/http-server": "^2.0.1",
+        "@dcl/schemas": "^25.1.0",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^2.0.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -24182,8 +24018,7 @@
         "@types/reach__router": "^1.3.9",
         "@types/react-helmet": "^6.1.4",
         "@types/validator": "^13.6.6",
-        "@well-known-components/http-server": "^1.1.5",
-        "@well-known-components/interfaces": "^1.1.2",
+        "@well-known-components/interfaces": "^1.5.2",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "analytics-node": "^6.2.0",
@@ -24199,8 +24034,7 @@
         "ddos": "^0.2.1",
         "decentraland-commons": "^5.1.0",
         "decentraland-connect": "^12.0.0",
-        "decentraland-crypto-middleware": "^1.3.0",
-        "decentraland-dapps": "^28.0.0",
+        "decentraland-dapps": "^28.4.0",
         "decentraland-server": "^3.0.0",
         "eth-sig-util": "^3.0.1",
         "express": "^4.17.1",
@@ -24253,9 +24087,9 @@
       }
     },
     "node_modules/decentraland-gatsby/node_modules/@dcl/schemas": {
-      "version": "22.5.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-22.5.0.tgz",
-      "integrity": "sha512-cl3mCoB/G5CmG6KVFyWVl+9y9bP6Jzm/YKzdiuR8ej3843OxTt91SQBrBbVtrGsBVJeebTEPhwSrB2CIiMzXjg==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-25.3.0.tgz",
+      "integrity": "sha512-ChFW3jU3ELN6YsRvs8TZIueBR8/DDxFcWPOeCoPafjLzSRK4GX9wHYrD3Crent07C3i3tm1rX8L/2rw+S39bzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -27769,28 +27603,28 @@
       }
     },
     "node_modules/ethereum-cryptography": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
-      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.2.0",
-        "@noble/secp256k1": "1.7.1",
-        "@scure/bip32": "1.1.5",
-        "@scure/bip39": "1.1.1"
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
       }
     },
-    "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
-      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/ethereumjs-abi": {
       "version": "0.6.8",
@@ -28283,26 +28117,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/ms": {
@@ -31487,37 +31301,23 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-https": {
@@ -37815,14 +37615,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/passport-strategy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/password-prompt": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
@@ -39717,26 +39509,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/raw-loader": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
@@ -40819,6 +40591,12 @@
         "redux": "^4"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -41885,26 +41663,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/send/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "apicache": "^1.6.2",
     "aws-sdk": "^2.1002.0",
     "dcl-catalyst-client": "^22.0.0",
-    "decentraland-gatsby": "^8.1.0",
+    "decentraland-gatsby": "^8.4.5",
     "express-fileupload": "^1.2.1",
     "html-escaper": "^3.0.3",
     "node-pg-migrate": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "abort-controller": "^3.0.0",
     "apicache": "^1.6.2",
     "aws-sdk": "^2.1002.0",
-    "dcl-catalyst-client": "^21.5.0",
+    "dcl-catalyst-client": "^22.0.0",
     "decentraland-gatsby": "^8.1.0",
     "express-fileupload": "^1.2.1",
     "html-escaper": "^3.0.3",

--- a/scripts/test-update-event-auth.ts
+++ b/scripts/test-update-event-auth.ts
@@ -14,7 +14,6 @@
  */
 import { Authenticator } from "@dcl/crypto"
 import { Wallet } from "ethers"
-import fetch from "node-fetch"
 
 import { signedHeaderFactory } from "decentraland-crypto-fetch"
 
@@ -67,7 +66,7 @@ async function main() {
   const createHeaders = signedHeaderFactory()
   const headers = createHeaders(identity, "PATCH", path, {})
 
-  // Convert Headers to plain object for node-fetch
+  // Convert Headers to a plain object for fetch
   const headerObj: Record<string, string> = {}
   headers.forEach((value: string, key: string) => {
     headerObj[key] = value
@@ -115,11 +114,14 @@ async function main() {
       process.exit(2)
     }
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      (error as NodeJS.ErrnoException).code === "ECONNREFUSED"
-    ) {
+    // Native fetch wraps network failures as a TypeError and puts the
+    // underlying OS error (e.g. ECONNREFUSED) on `error.cause`.
+    const code =
+      error instanceof Error
+        ? ((error as NodeJS.ErrnoException).code ??
+          (error.cause as NodeJS.ErrnoException | undefined)?.code)
+        : undefined
+    if (code === "ECONNREFUSED") {
       console.error(
         `ERROR: Could not connect to ${baseUrl}. Is the server running?`
       )

--- a/scripts/test-update-event-auth.ts
+++ b/scripts/test-update-event-auth.ts
@@ -118,8 +118,8 @@ async function main() {
     // underlying OS error (e.g. ECONNREFUSED) on `error.cause`.
     const code =
       error instanceof Error
-        ? ((error as NodeJS.ErrnoException).code ??
-          (error.cause as NodeJS.ErrnoException | undefined)?.code)
+        ? (error as NodeJS.ErrnoException).code ??
+          (error.cause as NodeJS.ErrnoException | undefined)?.code
         : undefined
     if (code === "ECONNREFUSED") {
       console.error(


### PR DESCRIPTION
## what

replace direct `node-fetch` usage with node's built-in `fetch`, and bump `dcl-catalyst-client` so it stops pulling node-fetch.

## changes

- `bin/smokeTest.ts`: node-fetch's `timeout` option → `AbortSignal.timeout`; `init` typed as `RequestInit`
- `scripts/test-update-event-auth.ts`: dropped the node-fetch import; the `ECONNREFUSED` check now reads `error.cause` (native fetch wraps network failures as a `TypeError`)
- `dcl-catalyst-client` `^21.5.0` → `^22.0.0`: v22 swaps `cross-fetch` (→ node-fetch) for `@dcl/fetch-component` (→ `@dcl/core-commons`, native fetch). the `cache.catalysts.mainnet` contracts-snapshots import used by `src/modules/servers.ts` is unchanged in v22.

## notes

- the rest of the app's outbound HTTP already goes through `decentraland-gatsby`'s `API` client (which uses native fetch) — there was no node-fetch usage in `src/`.
- `node-fetch` still appears transitively (via `decentraland-gatsby`, `@0xsequence`, `@segment/analytics-next`, and a gatsby-pinned older catalyst-client), so it isn't gone from the dependency tree — this removes our direct usage and one transitive path.

## verification

- `npm run build` ✓
- `npm test` → 11 suites / 148 passed ✓
- lint + type-check on changed files ✓
