### PR TITLE
fix: cancel undrained native-fetch response bodies and bump decentraland-gatsby to 8.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apicache": "^1.6.2",
         "aws-sdk": "^2.1002.0",
         "dcl-catalyst-client": "^22.0.0",
-        "decentraland-gatsby": "^8.4.5",
+        "decentraland-gatsby": "^8.4.6",
         "express-fileupload": "^1.2.1",
         "html-escaper": "^3.0.3",
         "node-pg-migrate": "^6.0.0",
@@ -5288,9 +5288,9 @@
       }
     },
     "node_modules/@dcl/http-server": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.0.2.tgz",
-      "integrity": "sha512-tzzBrW0JtexwwZNB7yYLiKVhG8LysWf7Sy2xrLBrqF8BAsCWqeLvPqftKrLBHNkxAd66zHsi5P3Mg5I9GdvdRA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.1.0.tgz",
+      "integrity": "sha512-UqIFIo18JeKklM/RM0wEJ0u/DCGjikBHtQ1LzuQKjDK6SP9XgeVhukgCg5BmdW0D3Qzlql2i5CGpW4EdyfUiWQ==",
       "dependencies": {
         "@dcl/core-commons": "0.10.1",
         "@well-known-components/interfaces": "^1.5.1",
@@ -23991,9 +23991,9 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.5.tgz",
-      "integrity": "sha512-qqLEf35cf/1lPdka65dcBoRdqQf5kolSCI1HshqKm7+NYOzlE6Xwi0rLNL0Wvx1C9TragjwUtXhCHYSLfGku8w==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.6.tgz",
+      "integrity": "sha512-V72OrZzLWOvEY/GC4a3GZBAnN+Y/wlPVhdU6IS9W5KHC8aYcWwSpTybBsBV7GVoc9H/c92z8sVC43IauHkz6Sw==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",
@@ -24001,7 +24001,7 @@
         "@dcl/crypto": "^3.4.3",
         "@dcl/crypto-middleware": "^4.0.0",
         "@dcl/feature-flags": "^1.2.0",
-        "@dcl/http-server": "^2.0.1",
+        "@dcl/http-server": "^2.1.0",
         "@dcl/schemas": "^25.1.0",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "apicache": "^1.6.2",
     "aws-sdk": "^2.1002.0",
     "dcl-catalyst-client": "^22.0.0",
-    "decentraland-gatsby": "^8.4.5",
+    "decentraland-gatsby": "^8.4.6",
     "express-fileupload": "^1.2.1",
     "html-escaper": "^3.0.3",
     "node-pg-migrate": "^6.0.0",


### PR DESCRIPTION
## Summary

Bumps `decentraland-gatsby` and audits all server-side native-`fetch` sites for undrained response-body leaks introduced by the move to native fetch.

### decentraland-gatsby bump
- `decentraland-gatsby`: `^8.4.5` -> `^8.4.6` (lockfile resolves to `8.4.6`).
- Pulls in transitive `@dcl/http-server` `2.0.2` -> `2.1.0`.
- `8.4.6` ships the native-fetch migration plus the `API.fetch` timeout-body fix inside the library, so the repo's `API`-based callers (e.g. `src/api/Places.ts`, which extends gatsby's `API` and uses `this.fetch`) get the corrected behavior with no source change here.

### native fetch / node-fetch
- No `node-fetch` / `isomorphic-fetch` / `cross-fetch` is a direct dependency on `master` or this branch, and none is imported anywhere under `src/`. The remaining `node-fetch` entries in the lockfile are deep transitive dependencies of unrelated packages and are intentionally left untouched. Nothing to drop.

### Raw fetch site audit
All raw `fetch(...)` call sites under `src/` were re-read:
- `src/entities/Slack/utils.ts` -> `sendToSlack()` (webhook POST, line ~302): the response body is consumed unconditionally via `await response.text()` on every code path (success and `status >= 400`), so there is no discard path that leaves the body undrained. No `.body.cancel()` is needed or added here — adding one would be a double-consume bug after `.text()`.
- `src/api/Places.ts`: uses `this.fetch` from gatsby's `API`, not a raw native fetch; covered by the library fix.
- No raw `fetch(...)` exists in any `.tsx` frontend component, so no browser-side body cancel was (incorrectly) added.

Net effect: the only application change required is the version bump; no source edits were necessary.

## Verification
- Typecheck (`npx tsc -p . --noEmit`): pass, 0 errors.
- Lint (`npm run lint`): pass, 0 errors (11 pre-existing warnings in untouched mocks/migrations).
- Unit tests (`npm test`): 11 suites passed, 148 tests passed.
- Integration tests (`test/integration/**`): skipped — require a Postgres instance that is unavailable in this environment; they are also excluded by `jest.config.js` (`<rootDir>/test/` ignore pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
