### PR TITLE
support multiple time slots for the same recurring event

### DIFF
--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -41,6 +41,7 @@ erDiagram
     INTEGER recurrent_count
     TIMESTAMP recurrent_until
     INTEGER duration
+    JSONB time_slots
     TIMESTAMP[] recurrent_dates
     INTEGER recurrent_setpos
     INTEGER recurrent_monthday
@@ -142,62 +143,63 @@ Stores all event information including one-time and recurrent events with locati
 
 ### Columns
 
-| Column                   | Type          | Nullable | Description                                                     |
-| ------------------------ | ------------- | -------- | --------------------------------------------------------------- |
-| `id`                     | UUID          | NOT NULL | **Primary Key**. Unique event identifier                        |
-| `name`                   | TEXT          | NOT NULL | Event name/title                                                |
-| `image`                  | TEXT          | NULL     | URL to event poster image stored in S3                          |
-| `description`            | TEXT          | NULL     | Event description in markdown format                            |
-| `start_at`               | TIMESTAMP     | NOT NULL | Event start time in UTC                                         |
-| `finish_at`              | TIMESTAMP     | NOT NULL | Event end time in UTC                                           |
-| `coordinates`            | INTEGER[]     | NOT NULL | Array of [x, y] coordinates in Decentraland Genesis City        |
-| `next_start_at`          | TIMESTAMP     | NOT NULL | Next occurrence start time for recurrent events                 |
-| `next_finish_at`         | TIMESTAMP     | NOT NULL | Next occurrence end time for recurrent events                   |
-| `duration`               | INTEGER       | NOT NULL | Event duration in milliseconds                                  |
-| `all_day`                | BOOLEAN       | NOT NULL | Whether event is all-day (default: false)                       |
-| `x`                      | INTEGER       | NOT NULL | X coordinate in Decentraland Genesis City (default: 0)          |
-| `y`                      | INTEGER       | NOT NULL | Y coordinate in Decentraland Genesis City (default: 0)          |
-| `server`                 | TEXT          | NULL     | **Deprecated**. Server/realm name (use world field instead)     |
-| `url`                    | TEXT          | NULL     | Custom event URL or external link                               |
-| `scene_name`             | TEXT          | NULL     | Name of the scene where the event takes place                   |
-| `user`                   | TEXT          | NOT NULL | Creator wallet address. Stored in lowercase                     |
-| `user_name`              | TEXT          | NULL     | Creator display name                                            |
-| `estate_id`              | TEXT          | NULL     | Associated Decentraland estate ID                               |
-| `estate_name`            | TEXT          | NULL     | Estate name for display                                         |
-| `approved`               | BOOLEAN       | NOT NULL | Approval status by moderator (default: false)                   |
-| `rejected`               | BOOLEAN       | NOT NULL | Rejection status by moderator (default: false)                  |
-| `approved_by`            | TEXT          | NULL     | Moderator wallet address who approved. Stored in lowercase      |
-| `rejected_by`            | TEXT          | NULL     | Moderator wallet address who rejected. Stored in lowercase      |
-| `rejection_reason`       | TEXT          | NULL     | Reason provided by a moderator or service when rejecting        |
-| `deleted_by_user`        | BOOLEAN       | NOT NULL | True if the creator soft-deleted the event (default: false)     |
-| `deleted_by_admin`       | BOOLEAN       | NOT NULL | True if an admin soft-deleted the event (default: false)        |
-| `deleted_by`             | TEXT          | NULL     | Wallet address or admin actor that deleted. Stored in lowercase |
-| `deleted_at`             | TIMESTAMP     | NULL     | Time the event was soft-deleted                                 |
-| `deleted_reason`         | TEXT          | NULL     | Reason provided by an admin when deleting (optional)            |
-| `highlighted`            | BOOLEAN       | NOT NULL | Featured/highlighted status (default: false)                    |
-| `trending`               | BOOLEAN       | NOT NULL | Trending status calculated algorithmically (default: false)     |
-| `recurrent`              | BOOLEAN       | NOT NULL | Whether event is recurrent (default: false)                     |
-| `recurrent_frequency`    | TEXT          | NULL     | RRule frequency: YEARLY, MONTHLY, WEEKLY, DAILY, HOURLY         |
-| `recurrent_setpos`       | INTEGER       | NULL     | Position in recurrence pattern (e.g., 1 for first, -1 for last) |
-| `recurrent_monthday`     | INTEGER       | NULL     | Day of month for monthly recurrence (1-31)                      |
-| `recurrent_weekday_mask` | INTEGER       | NOT NULL | Bitmask for weekdays (default: 0)                               |
-| `recurrent_month_mask`   | INTEGER       | NOT NULL | Bitmask for months (default: 0)                                 |
-| `recurrent_interval`     | INTEGER       | NOT NULL | Interval between occurrences (default: 1)                       |
-| `recurrent_count`        | INTEGER       | NULL     | Total number of occurrences                                     |
-| `recurrent_until`        | TIMESTAMP     | NULL     | Recurrence end date                                             |
-| `recurrent_dates`        | TIMESTAMP[]   | NOT NULL | Pre-calculated array of occurrence dates (default: {})          |
-| `contact`                | TEXT          | NULL     | Contact information for event organizer                         |
-| `details`                | TEXT          | NULL     | Additional event details or notes                               |
-| `total_attendees`        | INTEGER       | NOT NULL | Denormalized count of attendees (default: 0)                    |
-| `latest_attendees`       | TEXT[]        | NOT NULL | Array of recent attendee addresses (default: {})                |
-| `textsearch`             | TSVECTOR      | NULL     | Full-text search vector for name and description                |
-| `categories`             | VARCHAR(50)[] | NOT NULL | Array of event category tags (default: {})                      |
-| `schedules`              | UUID[]        | NOT NULL | Array of associated schedule IDs (default: {})                  |
-| `world`                  | BOOLEAN       | NOT NULL | Whether event is in a virtual world vs land (default: false)    |
-| `place_id`               | TEXT          | NULL     | Associated place ID from Catalyst                               |
-| `community_id`           | TEXT          | NULL     | Associated community ID from Communities API                    |
-| `created_at`             | TIMESTAMP     | NOT NULL | Creation timestamp (default: now())                             |
-| `updated_at`             | TIMESTAMP     | NOT NULL | Last update timestamp (default: now())                          |
+| Column                   | Type          | Nullable | Description                                                                                                                                                                                        |
+| ------------------------ | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                     | UUID          | NOT NULL | **Primary Key**. Unique event identifier                                                                                                                                                           |
+| `name`                   | TEXT          | NOT NULL | Event name/title                                                                                                                                                                                   |
+| `image`                  | TEXT          | NULL     | URL to event poster image stored in S3                                                                                                                                                             |
+| `description`            | TEXT          | NULL     | Event description in markdown format                                                                                                                                                               |
+| `start_at`               | TIMESTAMP     | NOT NULL | Event start time in UTC                                                                                                                                                                            |
+| `finish_at`              | TIMESTAMP     | NOT NULL | Event end time in UTC                                                                                                                                                                              |
+| `coordinates`            | INTEGER[]     | NOT NULL | Array of [x, y] coordinates in Decentraland Genesis City                                                                                                                                           |
+| `next_start_at`          | TIMESTAMP     | NOT NULL | Next occurrence start time for recurrent events                                                                                                                                                    |
+| `next_finish_at`         | TIMESTAMP     | NOT NULL | Next occurrence end time for recurrent events                                                                                                                                                      |
+| `duration`               | INTEGER       | NOT NULL | Event duration in milliseconds                                                                                                                                                                     |
+| `time_slots`             | JSONB         | NOT NULL | Array of `{time, duration}` showings: `time` = minutes since midnight UTC, `duration` in ms. Single-slot events hold one entry mirroring `start_at`/`duration` (default: `[]`, normalized on read) |
+| `all_day`                | BOOLEAN       | NOT NULL | Whether event is all-day (default: false)                                                                                                                                                          |
+| `x`                      | INTEGER       | NOT NULL | X coordinate in Decentraland Genesis City (default: 0)                                                                                                                                             |
+| `y`                      | INTEGER       | NOT NULL | Y coordinate in Decentraland Genesis City (default: 0)                                                                                                                                             |
+| `server`                 | TEXT          | NULL     | **Deprecated**. Server/realm name (use world field instead)                                                                                                                                        |
+| `url`                    | TEXT          | NULL     | Custom event URL or external link                                                                                                                                                                  |
+| `scene_name`             | TEXT          | NULL     | Name of the scene where the event takes place                                                                                                                                                      |
+| `user`                   | TEXT          | NOT NULL | Creator wallet address. Stored in lowercase                                                                                                                                                        |
+| `user_name`              | TEXT          | NULL     | Creator display name                                                                                                                                                                               |
+| `estate_id`              | TEXT          | NULL     | Associated Decentraland estate ID                                                                                                                                                                  |
+| `estate_name`            | TEXT          | NULL     | Estate name for display                                                                                                                                                                            |
+| `approved`               | BOOLEAN       | NOT NULL | Approval status by moderator (default: false)                                                                                                                                                      |
+| `rejected`               | BOOLEAN       | NOT NULL | Rejection status by moderator (default: false)                                                                                                                                                     |
+| `approved_by`            | TEXT          | NULL     | Moderator wallet address who approved. Stored in lowercase                                                                                                                                         |
+| `rejected_by`            | TEXT          | NULL     | Moderator wallet address who rejected. Stored in lowercase                                                                                                                                         |
+| `rejection_reason`       | TEXT          | NULL     | Reason provided by a moderator or service when rejecting                                                                                                                                           |
+| `deleted_by_user`        | BOOLEAN       | NOT NULL | True if the creator soft-deleted the event (default: false)                                                                                                                                        |
+| `deleted_by_admin`       | BOOLEAN       | NOT NULL | True if an admin soft-deleted the event (default: false)                                                                                                                                           |
+| `deleted_by`             | TEXT          | NULL     | Wallet address or admin actor that deleted. Stored in lowercase                                                                                                                                    |
+| `deleted_at`             | TIMESTAMP     | NULL     | Time the event was soft-deleted                                                                                                                                                                    |
+| `deleted_reason`         | TEXT          | NULL     | Reason provided by an admin when deleting (optional)                                                                                                                                               |
+| `highlighted`            | BOOLEAN       | NOT NULL | Featured/highlighted status (default: false)                                                                                                                                                       |
+| `trending`               | BOOLEAN       | NOT NULL | Trending status calculated algorithmically (default: false)                                                                                                                                        |
+| `recurrent`              | BOOLEAN       | NOT NULL | Whether event is recurrent (default: false)                                                                                                                                                        |
+| `recurrent_frequency`    | TEXT          | NULL     | RRule frequency: YEARLY, MONTHLY, WEEKLY, DAILY, HOURLY                                                                                                                                            |
+| `recurrent_setpos`       | INTEGER       | NULL     | Position in recurrence pattern (e.g., 1 for first, -1 for last)                                                                                                                                    |
+| `recurrent_monthday`     | INTEGER       | NULL     | Day of month for monthly recurrence (1-31)                                                                                                                                                         |
+| `recurrent_weekday_mask` | INTEGER       | NOT NULL | Bitmask for weekdays (default: 0)                                                                                                                                                                  |
+| `recurrent_month_mask`   | INTEGER       | NOT NULL | Bitmask for months (default: 0)                                                                                                                                                                    |
+| `recurrent_interval`     | INTEGER       | NOT NULL | Interval between occurrences (default: 1)                                                                                                                                                          |
+| `recurrent_count`        | INTEGER       | NULL     | Total number of occurrences                                                                                                                                                                        |
+| `recurrent_until`        | TIMESTAMP     | NULL     | Recurrence end date                                                                                                                                                                                |
+| `recurrent_dates`        | TIMESTAMP[]   | NOT NULL | Pre-calculated array of occurrence dates (default: {})                                                                                                                                             |
+| `contact`                | TEXT          | NULL     | Contact information for event organizer                                                                                                                                                            |
+| `details`                | TEXT          | NULL     | Additional event details or notes                                                                                                                                                                  |
+| `total_attendees`        | INTEGER       | NOT NULL | Denormalized count of attendees (default: 0)                                                                                                                                                       |
+| `latest_attendees`       | TEXT[]        | NOT NULL | Array of recent attendee addresses (default: {})                                                                                                                                                   |
+| `textsearch`             | TSVECTOR      | NULL     | Full-text search vector for name and description                                                                                                                                                   |
+| `categories`             | VARCHAR(50)[] | NOT NULL | Array of event category tags (default: {})                                                                                                                                                         |
+| `schedules`              | UUID[]        | NOT NULL | Array of associated schedule IDs (default: {})                                                                                                                                                     |
+| `world`                  | BOOLEAN       | NOT NULL | Whether event is in a virtual world vs land (default: false)                                                                                                                                       |
+| `place_id`               | TEXT          | NULL     | Associated place ID from Catalyst                                                                                                                                                                  |
+| `community_id`           | TEXT          | NULL     | Associated community ID from Communities API                                                                                                                                                       |
+| `created_at`             | TIMESTAMP     | NOT NULL | Creation timestamp (default: now())                                                                                                                                                                |
+| `updated_at`             | TIMESTAMP     | NOT NULL | Last update timestamp (default: now())                                                                                                                                                             |
 
 ### Indexes
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1342,8 +1342,30 @@ components:
           example: "2024-12-25T20:00:00.000Z"
         duration:
           type: integer
-          description: Event duration in milliseconds
+          description: >-
+            Event duration in milliseconds. For events with multiple
+            time_slots this is the earliest slot's duration — do not
+            compute occurrence end times as next_start_at + duration;
+            use next_finish_at (or the matching time_slots entry)
+            instead.
           example: 7200000
+        time_slots:
+          type: array
+          description: >-
+            Time-of-day (minutes since midnight UTC) and duration of each
+            showing of the event. A single-slot event has one entry
+            matching start_at/duration.
+          items:
+            type: object
+            properties:
+              time:
+                type: integer
+                description: Minutes since midnight UTC
+                example: 840
+              duration:
+                type: integer
+                description: Duration of this time slot in milliseconds
+                example: 3600000
         all_day:
           type: boolean
           description: Whether this is an all-day event
@@ -1611,6 +1633,29 @@ components:
           minimum: 0
           maximum: 86400000
           description: Event duration in milliseconds (max 24 hours)
+        time_slots:
+          type: array
+          description: >-
+            Optional list of time-of-day + duration showings for the
+            event. Defaults to a single slot derived from start_at/duration
+            when omitted. Multiple slots are not supported for HOURLY
+            recurrence.
+          minItems: 1
+          maxItems: 6
+          items:
+            type: object
+            required: [time, duration]
+            properties:
+              time:
+                type: integer
+                description: Minutes since midnight UTC
+                minimum: 0
+                maximum: 1439
+              duration:
+                type: integer
+                description: Duration of this time slot in milliseconds
+                minimum: 1
+                maximum: 86400000
         all_day:
           type: boolean
           default: false
@@ -1736,6 +1781,27 @@ components:
         duration:
           type: integer
           minimum: 0
+        time_slots:
+          type: array
+          description: >-
+            Optional list of time-of-day + duration showings for the
+            event. Multiple slots are not supported for HOURLY recurrence.
+          minItems: 1
+          maxItems: 6
+          items:
+            type: object
+            required: [time, duration]
+            properties:
+              time:
+                type: integer
+                description: Minutes since midnight UTC
+                minimum: 0
+                maximum: 1439
+              duration:
+                type: integer
+                description: Duration of this time slot in milliseconds
+                minimum: 1
+                maximum: 86400000
         all_day:
           type: boolean
         x:

--- a/src/entities/Event/cron.test.ts
+++ b/src/entities/Event/cron.test.ts
@@ -13,6 +13,12 @@ function makeEvent(overrides: Record<string, unknown> = {}) {
     start_at: startAt,
     finish_at: new Date(startAt.getTime() + 60 * 60 * 1000),
     duration: 60 * 60 * 1000,
+    time_slots: [
+      {
+        time: startAt.getUTCHours() * 60 + startAt.getUTCMinutes(),
+        duration: 60 * 60 * 1000,
+      },
+    ],
     recurrent: true,
     recurrent_interval: 1,
     recurrent_frequency: Frequency.DAILY,

--- a/src/entities/Event/model.test.ts
+++ b/src/entities/Event/model.test.ts
@@ -1,4 +1,4 @@
-import EventModel from "./model"
+import EventModel, { serializeTimeSlotsForStorage } from "./model"
 import { EventListOptions, EventListType } from "./types"
 
 type SQLCondition = { text: string }
@@ -469,5 +469,109 @@ describe("EventModel.buildEventFilterConditions", () => {
         expect(hasCommunityIdCondition(conditions)).toBe(false)
       })
     })
+  })
+})
+
+describe("serializeTimeSlotsForStorage", () => {
+  it("JSON-stringifies time_slots when present", () => {
+    const payload = {
+      id: "event-1",
+      time_slots: [
+        { time: 840, duration: 3600000 },
+        { time: 1200, duration: 7200000 },
+      ],
+    }
+
+    expect(serializeTimeSlotsForStorage(payload)).toEqual({
+      id: "event-1",
+      time_slots: JSON.stringify(payload.time_slots),
+    })
+  })
+
+  it("passes payloads without time_slots through unchanged", () => {
+    const payload = { id: "event-1", name: "Watch Party" }
+    expect(serializeTimeSlotsForStorage(payload)).toEqual(payload)
+  })
+})
+
+describe("EventModel.selectNextStartAt", () => {
+  it("keeps next_start_at while its slot is still live", () => {
+    const now = Date.now()
+    const next_start_at = new Date(now - 10 * 60 * 1000)
+    const time_slots = [
+      {
+        time: next_start_at.getUTCHours() * 60 + next_start_at.getUTCMinutes(),
+        duration: 3600000,
+      },
+    ]
+
+    expect(
+      EventModel.selectNextStartAt(time_slots, next_start_at, [next_start_at])
+    ).toBe(next_start_at)
+  })
+
+  it("advances past a finished occurrence using its own slot duration", () => {
+    const now = Date.now()
+    const finished = new Date(now - 2 * 3600000)
+    const upcoming = new Date(now + 3600000)
+    const time_slots = [
+      {
+        time: finished.getUTCHours() * 60 + finished.getUTCMinutes(),
+        duration: 3600000,
+      },
+      {
+        time: upcoming.getUTCHours() * 60 + upcoming.getUTCMinutes(),
+        duration: 3600000,
+      },
+    ]
+
+    expect(
+      EventModel.selectNextStartAt(time_slots, finished, [finished, upcoming])
+    ).toBe(upcoming)
+  })
+})
+
+describe("EventModel.build", () => {
+  it("keeps recurrent_dates[0] equal to the normalized start_at and defaults time_slots", () => {
+    const start_at = new Date("2026-07-08T14:00:00.000Z")
+    const built = EventModel.build({
+      id: "event-1",
+      start_at,
+      finish_at: new Date(start_at.getTime() + 3600000),
+      duration: 3600000,
+      time_slots: [],
+      recurrent_dates: [],
+      next_start_at: null,
+    } as any)
+
+    expect(built!.recurrent_dates[0].getTime()).toBe(start_at.getTime())
+    expect(built!.time_slots).toEqual([{ time: 14 * 60, duration: 3600000 }])
+  })
+})
+
+describe("EventModel.toPublic", () => {
+  it("computes live using the matching slot's duration", () => {
+    const now = Date.now()
+    const next_start_at = new Date(now - 30 * 60 * 1000)
+    const time_slots = [
+      {
+        time: next_start_at.getUTCHours() * 60 + next_start_at.getUTCMinutes(),
+        duration: 3600000,
+      },
+    ]
+
+    const result = EventModel.toPublic(
+      {
+        id: "event-1",
+        user: "0xabc",
+        time_slots,
+        duration: 3600000,
+        next_start_at,
+        recurrent_dates: [next_start_at],
+      } as any,
+      { user: "0xabc" } as any
+    )
+
+    expect(result.live).toBe(true)
   })
 })

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -21,12 +21,29 @@ import {
   EventAttributes,
   EventListOptions,
   EventListType,
+  EventTimeSlot,
   SITEMAP_ITEMS_PER_PAGE,
   SessionEventAttributes,
 } from "./types"
+import { finishForDate, normalizeTimeSlots } from "./utils"
 import { getEventCreatorDisplayName } from "../../modules/decentralandFoundationAddresses"
 import EventAttendee from "../EventAttendee/model"
 import { ProfileSettingsAttributes } from "../ProfileSettings/types"
+
+export function serializeTimeSlotsForStorage<T extends QueryPart>(
+  payload: T
+): T {
+  const time_slots = (payload as Partial<EventAttributes>).time_slots
+
+  if (!Array.isArray(time_slots)) {
+    return payload
+  }
+
+  return {
+    ...payload,
+    time_slots: JSON.stringify(time_slots),
+  }
+}
 
 export default class EventModel extends Model<DeprecatedEventAttributes> {
   static tableName = "events"
@@ -47,11 +64,12 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
   }
 
   static create<U extends QueryPart = any>(event: U): Promise<U> {
-    const keys = Object.keys(event).map((key) => key.replace(/\W/gi, ""))
+    const payload = serializeTimeSlotsForStorage(event)
+    const keys = Object.keys(payload).map((key) => key.replace(/\W/gi, ""))
 
     const sql = SQL`
       INSERT INTO ${table(this)} ${columns(keys)}
-      VALUES ${objectValues(keys, [event])}
+      VALUES ${objectValues(keys, [payload])}
     `
 
     return this.namedQuery("event_create", sql) as any
@@ -61,7 +79,8 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     changes: Partial<U>,
     conditions: Partial<P>
   ): Promise<U> {
-    const changesKeys = Object.keys(changes).map((key) =>
+    const payload = serializeTimeSlotsForStorage(changes)
+    const changesKeys = Object.keys(payload).map((key) =>
       key.replace(/\W/gi, "")
     )
     const conditionsKeys = Object.keys(conditions).map((key) =>
@@ -76,7 +95,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     }
 
     const updatedChanges = {
-      ...changes,
+      ...payload,
       updated_at: new Date(),
     }
 
@@ -102,18 +121,22 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
   }
 
   static selectNextStartAt(
-    duration: number,
+    time_slots: EventTimeSlot[],
     next_start_at: Date | null,
     recurrent_dates: Date[]
   ): Date {
     const now = Date.now()
-    if (next_start_at && next_start_at.getTime() + duration > now) {
+    if (
+      next_start_at &&
+      finishForDate(next_start_at, time_slots).getTime() > now
+    ) {
       return next_start_at
     }
 
     return (
-      recurrent_dates.find((date) => date.getTime() + duration > now) ||
-      recurrent_dates[recurrent_dates.length - 1]
+      recurrent_dates.find(
+        (date) => finishForDate(date, time_slots).getTime() > now
+      ) || recurrent_dates[recurrent_dates.length - 1]
     )
   }
 
@@ -129,6 +152,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     // TODO: remove
     const duration =
       Number(event.duration) || finish_at.getTime() - start_at.getTime()
+    const time_slots = normalizeTimeSlots(event.time_slots, start_at, duration)
     const recurrent_dates =
       Array.isArray(event.recurrent_dates) && event.recurrent_dates.length > 0
         ? event.recurrent_dates.map((date) => Time.date(date))
@@ -139,7 +163,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     }
 
     const next_start_at = this.selectNextStartAt(
-      duration,
+      time_slots,
       event.next_start_at && Time.date(event.next_start_at),
       recurrent_dates
     )
@@ -147,6 +171,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     return {
       ...event,
       duration,
+      time_slots,
       recurrent_dates,
       next_start_at,
       scene_name: event.estate_name,
@@ -307,6 +332,12 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     starting_from: number,
     starting_to: number
   ) {
+    // Multi-slot events keep next_start_at pinned to the current slot
+    // until it finishes, so a later same-day slot can enter (and leave)
+    // the look-ahead window while next_start_at still points at the
+    // previous slot — match any materialized occurrence for them.
+    // Single-slot events keep the next_start_at fast path (indexed,
+    // and preserves existing notification cadence).
     const query = SQL`
       SELECT *
       FROM ${table(EventModel)} e
@@ -315,8 +346,21 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         AND e.deleted_by_user IS FALSE
         AND e.deleted_by_admin IS FALSE
         AND e.approved IS TRUE
-        AND e.next_start_at >= (to_timestamp(${starting_from} / 1000.0))
-        AND e.next_start_at < (to_timestamp(${starting_to} / 1000.0))
+        AND (
+          (
+            e.next_start_at >= (to_timestamp(${starting_from} / 1000.0))
+            AND e.next_start_at < (to_timestamp(${starting_to} / 1000.0))
+          )
+          OR (
+            jsonb_array_length(e.time_slots) > 1
+            AND EXISTS (
+              SELECT 1
+              FROM unnest(e.recurrent_dates) AS occurrence
+              WHERE occurrence >= (to_timestamp(${starting_from} / 1000.0))
+                AND occurrence < (to_timestamp(${starting_to} / 1000.0))
+            )
+          )
+        )
     `
 
     return EventModel.buildAll(
@@ -373,7 +417,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
         AND e.deleted_by_admin IS FALSE
         AND e.recurrent IS TRUE
         AND e.finish_at > now()
-        AND (e.next_start_at + (e.duration * '1 millisecond'::interval)) < now()
+        AND e.next_finish_at < now()
     `
 
     return EventModel.buildAll(
@@ -494,12 +538,12 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
     const next_start_at =
       event.next_start_at ||
       event.recurrent_dates.find(
-        (date) => date.getTime() + event.duration > now
+        (date) => finishForDate(date, event.time_slots).getTime() > now
       ) ||
       event.recurrent_dates[event.recurrent_dates.length - 1]
+    const next_finish_at = finishForDate(next_start_at, event.time_slots)
     const live =
-      now >= next_start_at.getTime() &&
-      now < next_start_at.getTime() + event.duration
+      now >= next_start_at.getTime() && now < next_finish_at.getTime()
 
     return {
       ...event,

--- a/src/entities/Event/routes/admin.test.ts
+++ b/src/entities/Event/routes/admin.test.ts
@@ -77,9 +77,11 @@ jest.mock("../utils", () => {
   const actual = jest.requireActual("../utils")
   return {
     ...actual,
-    calculateRecurrentProperties: () => ({
+    calculateRecurrentProperties: (event: { duration: number }) => ({
       recurrent_dates: [new Date("2030-01-01T00:00:00Z")],
       finish_at: new Date("2030-01-01T01:00:00Z"),
+      duration: event.duration,
+      time_slots: [{ time: 0, duration: event.duration }],
     }),
     estimateRecurrentPastIterations: () => 0,
     eventTargetUrl: () => "https://decentraland.org/jump?position=0,0",
@@ -155,6 +157,7 @@ function createBaseEvent(
     next_start_at: startAt,
     next_finish_at: new Date("2030-01-01T01:00:00Z"),
     duration: 3600000,
+    time_slots: [{ time: 0, duration: 3600000 }],
     all_day: false,
     x: 0,
     y: 0,

--- a/src/entities/Event/routes/createEvent.ts
+++ b/src/entities/Event/routes/createEvent.ts
@@ -22,14 +22,15 @@ import { newEventSchema } from "../schemas"
 import {
   DeprecatedEventAttributes,
   EventAttributes,
-  MAX_EVENT_DURATION,
   MAX_RECURRENT_PAST_ITERATIONS,
 } from "../types"
 import {
   calculateRecurrentProperties,
   estimateRecurrentPastIterations,
   eventTargetUrl,
+  finishForDate,
   validateImageUrl,
+  validateTimeSlots,
 } from "../utils"
 
 const validateNewEvent = createValidator<EventAttributes>(
@@ -116,13 +117,7 @@ export async function createEvent(req: WithAuthProfile<WithAuth>) {
 
   const recurrent = calculateRecurrentProperties(data)
 
-  if (recurrent.duration > MAX_EVENT_DURATION) {
-    throw new RequestError(
-      `Maximum allowed duration ${MAX_EVENT_DURATION / Time.Hour}Hrs`,
-      RequestError.BadRequest,
-      { body: data }
-    )
-  }
+  validateTimeSlots(recurrent.time_slots, recurrent.recurrent_frequency)
 
   if (data.categories.length) {
     const validation = await EventCategoryModel.validateCategories(
@@ -189,11 +184,11 @@ export async function createEvent(req: WithAuthProfile<WithAuth>) {
 
   const user_name = userProfile.name || null
   const next_start_at = EventModel.selectNextStartAt(
-    recurrent.duration,
+    recurrent.time_slots,
     recurrent.start_at,
     recurrent.recurrent_dates
   )
-  const next_finish_at = new Date(next_start_at.getTime() + recurrent.duration)
+  const next_finish_at = finishForDate(next_start_at, recurrent.time_slots)
 
   const event: DeprecatedEventAttributes = {
     ...data,

--- a/src/entities/Event/routes/updateEvent.test.ts
+++ b/src/entities/Event/routes/updateEvent.test.ts
@@ -61,9 +61,11 @@ jest.mock("../utils", () => {
   const actual = jest.requireActual("../utils")
   return {
     ...actual,
-    calculateRecurrentProperties: () => ({
+    calculateRecurrentProperties: (event: { duration: number }) => ({
       recurrent_dates: [new Date("2030-01-01T00:00:00Z")],
       finish_at: new Date("2030-01-01T01:00:00Z"),
+      duration: event.duration,
+      time_slots: [{ time: 0, duration: event.duration }],
     }),
     eventTargetUrl: () => "https://decentraland.org/jump",
     validateImageUrl: () => Promise.resolve(undefined),
@@ -128,6 +130,7 @@ function createBaseEvent(
     next_start_at: startAt,
     next_finish_at: new Date("2030-01-01T01:00:00Z"),
     duration: 3600000,
+    time_slots: [{ time: 0, duration: 3600000 }],
     all_day: false,
     x: 0,
     y: 0,

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -54,8 +54,11 @@ import {
   calculateRecurrentProperties,
   estimateRecurrentPastIterations,
   eventTargetUrl,
+  finishForDate,
+  minutesOfDay,
   validateImageUrl,
   validateRejectionReason,
+  validateTimeSlots,
 } from "../utils"
 
 const validateUpdateEvent = createValidator<DeprecatedEventAttributes>(
@@ -180,6 +183,49 @@ export async function updateEventWithOptions(
     updatedAttributes.recurrent_until
   )
 
+  // `time_slots` is always carried over from the stored event via
+  // `pick(event, editEventAttributes)` even when the request doesn't
+  // send it. Two hazards follow:
+  //
+  // - Single-slot events: the carried slot mirrors the stored
+  //   duration/start_at, so it would override a freshly patched
+  //   duration/start_at (and a grandfathered out-of-bounds duration
+  //   would fail schema validation on a request that never touched
+  //   it). Drop the key and let calculateRecurrentProperties re-derive
+  //   the slot from the merged duration/start_at.
+  // - Multi-slot events: duration and start_at's time-of-day are
+  //   DERIVED from the slots, so a request that tries to change them
+  //   without resending time_slots would be silently discarded.
+  //   Reject those explicitly instead.
+  if (req.body.time_slots === undefined) {
+    if (updatedAttributes.time_slots.length <= 1) {
+      delete (updatedAttributes as Partial<EventAttributes>).time_slots
+    } else {
+      if (
+        req.body.duration !== undefined &&
+        req.body.duration !== updatedAttributes.time_slots[0].duration
+      ) {
+        throw new RequestError(
+          `duration is derived from time_slots on events with multiple time slots; edit time_slots instead`,
+          RequestError.BadRequest,
+          { body: req.body }
+        )
+      }
+
+      const patched_start_at = req.body.start_at && Time.date(req.body.start_at)
+      if (
+        patched_start_at &&
+        minutesOfDay(patched_start_at) !== updatedAttributes.time_slots[0].time
+      ) {
+        throw new RequestError(
+          `start_at time-of-day is derived from time_slots on events with multiple time slots; edit time_slots instead`,
+          RequestError.BadRequest,
+          { body: req.body }
+        )
+      }
+    }
+  }
+
   validateUpdateEvent({
     ...updatedAttributes,
     start_at: Time.date(updatedAttributes.start_at)?.toJSON(),
@@ -251,20 +297,6 @@ export async function updateEventWithOptions(
     }
   }
 
-  /**
-   * Verify that the duration event is not longer than the max allowed or the previous duration
-   */
-  if (
-    updatedAttributes.duration &&
-    updatedAttributes.duration > Math.max(event.duration, MAX_EVENT_DURATION)
-  ) {
-    throw new RequestError(
-      `Maximum allowed duration ${MAX_EVENT_DURATION / Time.Hour}Hrs`,
-      RequestError.BadRequest,
-      { body: updatedAttributes }
-    )
-  }
-
   const userProfiles = await Catalyst.getInstance().getProfiles([event.user])
   if (
     userProfiles &&
@@ -323,14 +355,27 @@ export async function updateEventWithOptions(
     calculateRecurrentProperties(updatedAttributes)
   )
 
+  // Cap mirrors the previous guard (`Math.max(event.duration, MAX)`)
+  // so grandfathered rows whose stored duration predates the cap stay
+  // editable as long as the duration doesn't grow.
+  validateTimeSlots(
+    updatedAttributes.time_slots,
+    updatedAttributes.recurrent_frequency,
+    Math.max(
+      MAX_EVENT_DURATION,
+      ...event.time_slots.map((slot) => slot.duration)
+    )
+  )
+
   updatedAttributes.next_start_at = EventModel.selectNextStartAt(
-    updatedAttributes.duration,
+    updatedAttributes.time_slots,
     updatedAttributes.start_at,
     updatedAttributes.recurrent_dates
   )
 
-  updatedAttributes.next_finish_at = new Date(
-    updatedAttributes.next_start_at.getTime() + updatedAttributes.duration
+  updatedAttributes.next_finish_at = finishForDate(
+    updatedAttributes.next_start_at,
+    updatedAttributes.time_slots
   )
 
   if (updatedAttributes.rejected) {

--- a/src/entities/Event/schemas.ts
+++ b/src/entities/Event/schemas.ts
@@ -6,7 +6,12 @@ import {
   apiResultSchema,
 } from "decentraland-gatsby/dist/entities/Schema/types"
 
-import { AllowedInputFrequencies, Frequencies } from "./types"
+import {
+  AllowedInputFrequencies,
+  Frequencies,
+  MAX_EVENT_DURATION,
+  MAX_EVENT_TIME_SLOTS,
+} from "./types"
 
 export const getEventParamsSchema: AjvObjectSchema = {
   type: "object",
@@ -369,6 +374,24 @@ export const eventSchema = {
     duration: {
       type: "number",
     },
+    time_slots: {
+      type: "array",
+      description:
+        "The time-of-day (minutes since midnight UTC) and duration of each showing of the event",
+      items: {
+        type: "object",
+        properties: {
+          time: {
+            type: "number",
+            description: "Minutes since midnight UTC",
+          },
+          duration: {
+            type: "number",
+            description: "Duration of this time slot in milliseconds",
+          },
+        },
+      },
+    },
     recurrent_dates: {
       type: "array",
       description: "The specific position",
@@ -569,6 +592,32 @@ export const newEventSchema = {
     duration: {
       type: "number",
       minimum: 0,
+    },
+    time_slots: {
+      type: "array",
+      description:
+        "Optional list of time-of-day + duration showings for the event. Defaults to a single slot derived from start_at/duration when omitted. Multiple slots are not supported for HOURLY recurrence.",
+      minItems: 1,
+      maxItems: MAX_EVENT_TIME_SLOTS,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["time", "duration"],
+        properties: {
+          time: {
+            type: "integer",
+            description: "Minutes since midnight UTC",
+            minimum: 0,
+            maximum: 1439,
+          },
+          duration: {
+            type: "number",
+            description: "Duration of this time slot in milliseconds",
+            exclusiveMinimum: 0,
+            maximum: MAX_EVENT_DURATION,
+          },
+        },
+      },
     },
     all_day: {
       type: "boolean",

--- a/src/entities/Event/types.ts
+++ b/src/entities/Event/types.ts
@@ -96,6 +96,12 @@ export enum Position {
 }
 
 export const MAX_EVENT_RECURRENT = 10
+export const MAX_EVENT_TIME_SLOTS = 6
+
+export type EventTimeSlot = {
+  time: number // minutes since midnight UTC, 0-1439
+  duration: number // milliseconds
+}
 
 export const MAX_REJECTION_REASON_LENGTH = 500
 export const MAX_DELETED_REASON_LENGTH = 500
@@ -133,6 +139,7 @@ export type EventAttributes = {
   next_start_at: Date
   next_finish_at: Date
   duration: number
+  time_slots: EventTimeSlot[]
   all_day: boolean
   x: number
   y: number
@@ -206,7 +213,9 @@ export type RecurrentEventAttributes = Pick<
   | "recurrent_month_mask"
   | "recurrent_until"
   | "recurrent_count"
->
+> & {
+  time_slots?: EventTimeSlot[]
+}
 
 export enum EventListType {
   All = "all",
@@ -280,6 +289,7 @@ export const editEventAttributes = [
   "description",
   "start_at",
   "duration",
+  "time_slots",
   "all_day",
   "x",
   "y",

--- a/src/entities/Event/utils.test.ts
+++ b/src/entities/Event/utils.test.ts
@@ -1,9 +1,24 @@
-import { Frequency, MAX_EVENT_RECURRENT } from "./types"
 import {
+  EventTimeSlot,
+  Frequency,
+  MAX_EVENT_DURATION,
+  MAX_EVENT_RECURRENT,
+  MAX_EVENT_TIME_SLOTS,
+} from "./types"
+import {
+  applyTimeOfDay,
+  calculateNextRecurrentDates,
+  calculateRecurrentProperties,
+  datesForDay,
   estimateRecurrentPastIterations,
+  finishForDate,
   fromEventTime,
   futureRecurrentDates,
+  minutesOfDay,
+  normalizeTimeSlots,
+  slotForDate,
   toEventTime,
+  validateTimeSlots,
 } from "./utils"
 
 test(`fromEventTime`, () => {
@@ -308,5 +323,376 @@ describe("estimateRecurrentPastIterations", () => {
       expect(result).toBeGreaterThan(360)
       expect(result).toBeLessThan(370)
     })
+  })
+})
+
+test(`minutesOfDay`, () => {
+  expect(minutesOfDay(new Date("2026-07-08T00:00:00.000Z"))).toBe(0)
+  expect(minutesOfDay(new Date("2026-07-08T14:00:00.000Z"))).toBe(14 * 60)
+  expect(minutesOfDay(new Date("2026-07-08T23:59:00.000Z"))).toBe(23 * 60 + 59)
+})
+
+test(`applyTimeOfDay`, () => {
+  const date = new Date("2026-07-08T03:15:20.500Z")
+  const result = applyTimeOfDay(date, 20 * 60, 45, 250)
+  expect(result.toISOString()).toBe("2026-07-08T20:00:45.250Z")
+  expect(date.toISOString()).toBe("2026-07-08T03:15:20.500Z") // no mutation
+})
+
+test(`normalizeTimeSlots without input derives a single slot from start_at/duration`, () => {
+  const start_at = new Date("2026-07-08T14:00:00.000Z")
+  expect(normalizeTimeSlots(undefined, start_at, 3600000)).toEqual([
+    { time: 14 * 60, duration: 3600000 },
+  ])
+  expect(normalizeTimeSlots([], start_at, 3600000)).toEqual([
+    { time: 14 * 60, duration: 3600000 },
+  ])
+})
+
+test(`normalizeTimeSlots sorts provided slots by time ascending`, () => {
+  const start_at = new Date("2026-07-08T14:00:00.000Z")
+  const result = normalizeTimeSlots(
+    [
+      { time: 20 * 60, duration: 1000 },
+      { time: 14 * 60, duration: 2000 },
+    ],
+    start_at,
+    9999
+  )
+  expect(result).toEqual([
+    { time: 14 * 60, duration: 2000 },
+    { time: 20 * 60, duration: 1000 },
+  ])
+})
+
+test(`datesForDay produces one date per slot, sorted, on the same calendar day`, () => {
+  const day = new Date("2026-07-08T14:00:30.123Z")
+  const time_slots: EventTimeSlot[] = [
+    { time: 20 * 60, duration: 1000 },
+    { time: 14 * 60, duration: 2000 },
+  ]
+  const result = datesForDay(day, time_slots, 30, 123)
+  expect(result.map((d) => d.toISOString())).toEqual([
+    "2026-07-08T14:00:30.123Z",
+    "2026-07-08T20:00:30.123Z",
+  ])
+})
+
+test(`slotForDate finds the slot matching the date's time-of-day, falls back to the first`, () => {
+  const time_slots: EventTimeSlot[] = [
+    { time: 14 * 60, duration: 1000 },
+    { time: 20 * 60, duration: 2000 },
+  ]
+  expect(slotForDate(new Date("2026-07-08T20:00:00.000Z"), time_slots)).toEqual(
+    { time: 20 * 60, duration: 2000 }
+  )
+  expect(slotForDate(new Date("2026-07-08T09:00:00.000Z"), time_slots)).toEqual(
+    { time: 14 * 60, duration: 1000 }
+  )
+})
+
+test(`finishForDate adds the matching slot's duration`, () => {
+  const time_slots: EventTimeSlot[] = [
+    { time: 14 * 60, duration: 1000 },
+    { time: 20 * 60, duration: 2000 },
+  ]
+  const date = new Date("2026-07-08T20:00:00.000Z")
+  expect(finishForDate(date, time_slots).getTime()).toBe(date.getTime() + 2000)
+})
+
+test(`validateTimeSlots accepts valid single and multi slots`, () => {
+  expect(() =>
+    validateTimeSlots([{ time: 840, duration: 3600000 }], null)
+  ).not.toThrow()
+  expect(() =>
+    validateTimeSlots(
+      [
+        { time: 840, duration: 3600000 },
+        { time: 1200, duration: 7200000 },
+      ],
+      Frequency.WEEKLY
+    )
+  ).not.toThrow()
+})
+
+test(`validateTimeSlots rejects an empty list`, () => {
+  expect(() => validateTimeSlots([], null)).toThrow()
+})
+
+test(`validateTimeSlots rejects more than MAX_EVENT_TIME_SLOTS`, () => {
+  const slots = Array.from({ length: MAX_EVENT_TIME_SLOTS + 1 }, (_, i) => ({
+    time: i * 10,
+    duration: 1000,
+  }))
+  expect(() => validateTimeSlots(slots, null)).toThrow()
+})
+
+test(`validateTimeSlots rejects multiple slots combined with HOURLY recurrence`, () => {
+  expect(() =>
+    validateTimeSlots(
+      [
+        { time: 0, duration: 1000 },
+        { time: 30, duration: 1000 },
+      ],
+      Frequency.HOURLY
+    )
+  ).toThrow()
+})
+
+test(`validateTimeSlots rejects duplicated times`, () => {
+  expect(() =>
+    validateTimeSlots(
+      [
+        { time: 840, duration: 1000 },
+        { time: 840, duration: 2000 },
+      ],
+      null
+    )
+  ).toThrow()
+})
+
+test(`validateTimeSlots rejects a negative or over-cap duration but allows zero (legacy)`, () => {
+  expect(() => validateTimeSlots([{ time: 840, duration: -1 }], null)).toThrow()
+  expect(() =>
+    validateTimeSlots([{ time: 840, duration: MAX_EVENT_DURATION + 1 }], null)
+  ).toThrow()
+  expect(() =>
+    validateTimeSlots([{ time: 840, duration: 0 }], null)
+  ).not.toThrow()
+})
+
+test(`validateTimeSlots accepts a raised max_duration for grandfathered rows`, () => {
+  const grandfathered = MAX_EVENT_DURATION * 2
+  expect(() =>
+    validateTimeSlots([{ time: 840, duration: grandfathered }], null)
+  ).toThrow()
+  expect(() =>
+    validateTimeSlots(
+      [{ time: 840, duration: grandfathered }],
+      null,
+      grandfathered
+    )
+  ).not.toThrow()
+  expect(() =>
+    validateTimeSlots(
+      [{ time: 840, duration: grandfathered + 1 }],
+      null,
+      grandfathered
+    )
+  ).toThrow()
+})
+
+describe("futureRecurrentDates with multiple time slots", () => {
+  it("expands each recurrence day into one date per time slot", () => {
+    const dates = futureRecurrentDates({
+      start_at: new Date("2020-01-01T14:00:00.000Z"), // a past Wednesday
+      duration: 3600000,
+      time_slots: [
+        { time: 14 * 60, duration: 3600000 },
+        { time: 20 * 60, duration: 3600000 },
+      ],
+      recurrent: true,
+      recurrent_frequency: Frequency.WEEKLY,
+      recurrent_interval: 1,
+      recurrent_setpos: null,
+      recurrent_monthday: null,
+      recurrent_weekday_mask: 0,
+      recurrent_month_mask: 0,
+      recurrent_until: new Date(Date.now() + 5 * 365 * 24 * 60 * 60 * 1000),
+      recurrent_count: null,
+    })
+
+    expect(dates.length).toBeGreaterThan(1)
+    expect(dates.length % 2).toBe(0) // always pairs of (14:00, 20:00)
+    for (let i = 0; i < dates.length; i += 2) {
+      expect(dates[i].getUTCHours()).toBe(14)
+      expect(dates[i + 1].getUTCHours()).toBe(20)
+      expect(dates[i].getUTCFullYear()).toBe(dates[i + 1].getUTCFullYear())
+      expect(dates[i].getUTCMonth()).toBe(dates[i + 1].getUTCMonth())
+      expect(dates[i].getUTCDate()).toBe(dates[i + 1].getUTCDate())
+    }
+  })
+
+  it("caps materialized occurrences at MAX_EVENT_RECURRENT distinct days", () => {
+    const now = Date.now()
+    // Both slots later today so the >= now filter drops nothing and
+    // the +1 day compensation would otherwise leave 11 days.
+    const slotA = new Date(now + 60 * 60 * 1000)
+    const slotB = new Date(now + 2 * 60 * 60 * 1000)
+
+    const dates = futureRecurrentDates({
+      start_at: slotA,
+      duration: 3600000,
+      time_slots: [
+        { time: minutesOfDay(slotA), duration: 3600000 },
+        { time: minutesOfDay(slotB), duration: 3600000 },
+      ],
+      recurrent: true,
+      recurrent_frequency: Frequency.DAILY,
+      recurrent_interval: 1,
+      recurrent_setpos: null,
+      recurrent_monthday: null,
+      recurrent_weekday_mask: 0,
+      recurrent_month_mask: 0,
+      recurrent_until: new Date(now + 365 * 24 * 60 * 60 * 1000),
+      recurrent_count: null,
+    })
+
+    const distinctDays = new Set(
+      dates.map((date) => date.toISOString().slice(0, 10))
+    )
+    expect(distinctDays.size).toBe(MAX_EVENT_RECURRENT)
+    expect(dates.length).toBe(MAX_EVENT_RECURRENT * 2)
+  })
+
+  it("surfaces today's later slot even after the earlier slot already passed", () => {
+    const now = Date.now()
+    const passedSlotTime = new Date(now - 30 * 60 * 1000) // 30 min ago
+    const upcomingSlotTime = new Date(now + 30 * 60 * 1000) // in 30 min
+
+    const dates = futureRecurrentDates({
+      start_at: passedSlotTime,
+      duration: 3600000,
+      time_slots: [
+        { time: minutesOfDay(passedSlotTime), duration: 3600000 },
+        { time: minutesOfDay(upcomingSlotTime), duration: 3600000 },
+      ],
+      recurrent: true,
+      recurrent_frequency: Frequency.DAILY,
+      recurrent_interval: 1,
+      recurrent_setpos: null,
+      recurrent_monthday: null,
+      recurrent_weekday_mask: 0,
+      recurrent_month_mask: 0,
+      recurrent_until: new Date(now + 365 * 24 * 60 * 60 * 1000),
+      recurrent_count: null,
+    })
+
+    expect(dates.length).toBeGreaterThan(0)
+    expect(dates[0].getTime()).toBeGreaterThanOrEqual(now)
+    expect(dates[0].getUTCHours()).toBe(upcomingSlotTime.getUTCHours())
+    expect(dates[0].getUTCMinutes()).toBe(upcomingSlotTime.getUTCMinutes())
+  })
+})
+
+describe("calculateRecurrentProperties", () => {
+  it("is byte-for-byte unchanged for legacy single-slot input", () => {
+    const start_at = new Date("2026-07-08T14:00:00.000Z")
+    const result = calculateRecurrentProperties({
+      start_at,
+      duration: 3600000,
+      finish_at: new Date(start_at.getTime() + 3600000),
+    })
+
+    expect(result.start_at.toISOString()).toBe("2026-07-08T14:00:00.000Z")
+    expect(result.duration).toBe(3600000)
+    expect(result.time_slots).toEqual([{ time: 14 * 60, duration: 3600000 }])
+    expect(result.recurrent_dates.map((d) => d.toISOString())).toEqual([
+      "2026-07-08T14:00:00.000Z",
+    ])
+    expect(result.finish_at.toISOString()).toBe("2026-07-08T15:00:00.000Z")
+  })
+
+  it("materializes all slots for a non-recurrent multi-slot event and normalizes start_at to the earliest slot", () => {
+    const start_at = new Date("2026-07-08T20:00:00.000Z") // deliberately the LATER slot
+    const result = calculateRecurrentProperties({
+      start_at,
+      duration: 3600000,
+      finish_at: new Date(start_at.getTime() + 3600000),
+      time_slots: [
+        { time: 20 * 60, duration: 3600000 }, // 20:00, 1h
+        { time: 14 * 60, duration: 10800000 }, // 14:00, 3h
+      ],
+    })
+
+    expect(result.start_at.toISOString()).toBe("2026-07-08T14:00:00.000Z")
+    expect(result.duration).toBe(10800000)
+    expect(result.time_slots).toEqual([
+      { time: 14 * 60, duration: 10800000 },
+      { time: 20 * 60, duration: 3600000 },
+    ])
+    expect(result.recurrent_dates.map((d) => d.toISOString())).toEqual([
+      "2026-07-08T14:00:00.000Z",
+      "2026-07-08T20:00:00.000Z",
+    ])
+    expect(result.finish_at.toISOString()).toBe("2026-07-08T21:00:00.000Z")
+  })
+
+  it("reconciles start_at/duration with a single explicitly-provided slot", () => {
+    // Client sends start_at at 14:00 but declares the (only) showing
+    // at 20:00 with a different duration — the slot is the source of
+    // truth, so start_at/duration/finish_at must follow it.
+    const start_at = new Date("2026-07-10T14:00:00.000Z")
+    const result = calculateRecurrentProperties({
+      start_at,
+      duration: 3600000,
+      finish_at: new Date(start_at.getTime() + 3600000),
+      time_slots: [{ time: 20 * 60, duration: 7200000 }],
+    })
+
+    expect(result.start_at.toISOString()).toBe("2026-07-10T20:00:00.000Z")
+    expect(result.duration).toBe(7200000)
+    expect(result.recurrent_dates.map((d) => d.toISOString())).toEqual([
+      "2026-07-10T20:00:00.000Z",
+    ])
+    expect(result.finish_at.toISOString()).toBe("2026-07-10T22:00:00.000Z")
+  })
+
+  it("handles a recurrent multi-slot event end-to-end", () => {
+    const start_at = new Date("2020-01-01T14:00:00.000Z")
+    const result = calculateRecurrentProperties({
+      start_at,
+      duration: 3600000,
+      finish_at: new Date(start_at.getTime() + 3600000),
+      time_slots: [
+        { time: 14 * 60, duration: 3600000 },
+        { time: 20 * 60, duration: 3600000 },
+      ],
+      recurrent: true,
+      recurrent_frequency: Frequency.WEEKLY,
+      recurrent_interval: 1,
+      recurrent_until: new Date(Date.now() + 5 * 365 * 24 * 60 * 60 * 1000),
+    } as any)
+
+    expect(result.recurrent_dates.length).toBeGreaterThan(0)
+    expect(result.recurrent_dates.length % 2).toBe(0)
+    const last = result.recurrent_dates[result.recurrent_dates.length - 1]
+    expect(result.finish_at.getTime()).toBe(last.getTime() + 3600000)
+  })
+})
+
+describe("calculateNextRecurrentDates", () => {
+  it("keeps next_start_at while its own slot is still live", () => {
+    const now = Date.now()
+    const start_at = new Date(now - 30 * 60 * 1000)
+    const time_slots: EventTimeSlot[] = [
+      { time: minutesOfDay(start_at), duration: 3600000 },
+    ]
+
+    const result = calculateNextRecurrentDates({
+      start_at,
+      time_slots,
+      recurrent_dates: [start_at],
+    } as any)
+
+    expect(result.next_start_at).toBe(start_at)
+    expect(result.next_finish_at.getTime()).toBe(start_at.getTime() + 3600000)
+  })
+
+  it("advances to the next recurrent_dates entry once the current slot finished", () => {
+    const now = Date.now()
+    const finished = new Date(now - 2 * 3600000)
+    const upcoming = new Date(now + 3600000)
+    const time_slots: EventTimeSlot[] = [
+      { time: minutesOfDay(finished), duration: 3600000 },
+    ]
+
+    const result = calculateNextRecurrentDates({
+      start_at: finished,
+      time_slots,
+      recurrent_dates: [finished, upcoming],
+    } as any)
+
+    expect(result.next_start_at).toBe(upcoming)
   })
 })

--- a/src/entities/Event/utils.ts
+++ b/src/entities/Event/utils.ts
@@ -8,10 +8,14 @@ import { RRule, Weekday } from "rrule"
 import {
   EventAttributes,
   EventTimeReference,
+  EventTimeSlot,
   EventType,
   FREQUENCY_PERIOD_MS,
+  Frequency,
   MAX_DELETED_REASON_LENGTH,
+  MAX_EVENT_DURATION,
   MAX_EVENT_RECURRENT,
+  MAX_EVENT_TIME_SLOTS,
   MAX_REJECTION_REASON_LENGTH,
   MonthMask,
   Months,
@@ -185,9 +189,12 @@ export function toRRule(options: RecurrentEventAttributes): RRule | null {
  * rules above `MAX_RECURRENT_PAST_ITERATIONS` before calling this.
  *
  * @param options - Recurrence rule attributes. `start_at` supplies the
- *   time-of-day for every emitted date.
- * @returns Up to `MAX_EVENT_RECURRENT` future `Date` objects in
- *   ascending order, each carrying the time-of-day from `start_at`.
+ *   time-of-day for every emitted date; with multiple `time_slots` each
+ *   day instead contributes one date per slot.
+ * @returns Occurrences covering up to `MAX_EVENT_RECURRENT` future
+ *   days, in ascending order. Single-slot rules emit one date per day
+ *   (max `MAX_EVENT_RECURRENT` dates); multi-slot rules emit one date
+ *   per slot per day (max `MAX_EVENT_RECURRENT × slots` dates).
  */
 export function futureRecurrentDates(
   options: RecurrentEventAttributes
@@ -217,20 +224,77 @@ export function futureRecurrentDates(
   // Our iterator only sees future dates and caps them at
   // MAX_EVENT_RECURRENT via the `len` argument (current result length
   // before push).
-  const dates = rrule.between(
-    now,
+  const time_slots = options.time_slots
+  if (!time_slots || time_slots.length <= 1) {
+    const dates = rrule.between(
+      now,
+      end,
+      /* inc */ true,
+      (_date, len) => len < MAX_EVENT_RECURRENT
+    )
+
+    return dates.map((date) =>
+      applyTimeOfDay(
+        date,
+        minutesOfDay(options.start_at),
+        options.start_at.getUTCSeconds(),
+        options.start_at.getUTCMilliseconds()
+      )
+    )
+  }
+
+  // Multiple time slots — only reachable for non-HOURLY frequencies
+  // (validateTimeSlots rejects HOURLY + multiple slots), where each
+  // rrule-generated date safely represents one calendar day that gets
+  // multiplied into one Date per slot.
+  //
+  // Anchored at the start of today (not `now`): a day's rrule occurrence
+  // carries only its earliest slot's time-of-day, so anchoring at `now`
+  // would drop "today" entirely once that time passes — even when a
+  // later slot today hasn't happened yet. The cap is bumped by one to
+  // compensate for today possibly being wholly in the past once
+  // expanded and filtered below — a single rrule.between() call, so no
+  // extra past-iteration walk.
+  const startOfToday = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  )
+  const days = rrule.between(
+    startOfToday,
     end,
     /* inc */ true,
-    (_date, len) => len < MAX_EVENT_RECURRENT
+    (_date, len) => len < MAX_EVENT_RECURRENT + 1
   )
 
-  return dates.map((date) => {
-    date.setUTCHours(options.start_at.getUTCHours())
-    date.setUTCMinutes(options.start_at.getUTCMinutes())
-    date.setUTCSeconds(options.start_at.getUTCSeconds())
-    date.setUTCMilliseconds(options.start_at.getUTCMilliseconds())
-    return date
-  })
+  const dates = days
+    .flatMap((date) =>
+      datesForDay(
+        date,
+        time_slots,
+        options.start_at.getUTCSeconds(),
+        options.start_at.getUTCMilliseconds()
+      )
+    )
+    .filter((date) => date.getTime() >= now.getTime())
+    .sort((a, b) => a.getTime() - b.getTime())
+
+  // The +1 above may leave one extra day when today survived the
+  // filter — trim back to MAX_EVENT_RECURRENT distinct days.
+  const result: Date[] = []
+  let dayCount = 0
+  let currentDay = ""
+  for (const date of dates) {
+    const day = date.toISOString().slice(0, 10)
+    if (day !== currentDay) {
+      currentDay = day
+      dayCount++
+      if (dayCount > MAX_EVENT_RECURRENT) {
+        break
+      }
+    }
+    result.push(date)
+  }
+
+  return result
 }
 
 /**
@@ -359,33 +423,157 @@ export function toRecurrentSetposName(date: Date) {
   }
 }
 
+export function minutesOfDay(date: Date): number {
+  return date.getUTCHours() * 60 + date.getUTCMinutes()
+}
+
+export function applyTimeOfDay(
+  date: Date,
+  timeOfDay: number,
+  seconds: number,
+  milliseconds: number
+): Date {
+  const result = new Date(date.getTime())
+  result.setUTCHours(Math.floor(timeOfDay / 60))
+  result.setUTCMinutes(timeOfDay % 60)
+  result.setUTCSeconds(seconds)
+  result.setUTCMilliseconds(milliseconds)
+  return result
+}
+
+export function normalizeTimeSlots(
+  time_slots: EventTimeSlot[] | null | undefined,
+  start_at: Date,
+  duration: number
+): EventTimeSlot[] {
+  if (!time_slots || time_slots.length === 0) {
+    return [{ time: minutesOfDay(start_at), duration }]
+  }
+
+  return [...time_slots].sort((a, b) => a.time - b.time)
+}
+
+export function datesForDay(
+  day: Date,
+  time_slots: EventTimeSlot[],
+  seconds: number,
+  milliseconds: number
+): Date[] {
+  return time_slots
+    .map((slot) => applyTimeOfDay(day, slot.time, seconds, milliseconds))
+    .sort((a, b) => a.getTime() - b.getTime())
+}
+
+export function slotForDate(
+  date: Date,
+  time_slots: EventTimeSlot[]
+): EventTimeSlot {
+  return (
+    time_slots.find((slot) => slot.time === minutesOfDay(date)) || time_slots[0]
+  )
+}
+
+export function finishForDate(date: Date, time_slots: EventTimeSlot[]): Date {
+  return new Date(date.getTime() + slotForDate(date, time_slots).duration)
+}
+
+/**
+ * @param max_duration - Per-slot duration cap. Defaults to
+ *   `MAX_EVENT_DURATION`; updates pass `Math.max(stored, MAX)` so
+ *   grandfathered rows whose duration predates the cap stay editable
+ *   (mirrors the previous `Math.max(event.duration, MAX)` guard).
+ *   Zero is allowed for the same reason: zero-duration events were
+ *   always accepted (schema `minimum: 0`) and exist in the wild.
+ */
+export function validateTimeSlots(
+  time_slots: EventTimeSlot[],
+  recurrent_frequency: Frequency | null,
+  max_duration: number = MAX_EVENT_DURATION
+): void {
+  if (time_slots.length === 0) {
+    throw new RequestError(
+      `Event must have at least one time slot`,
+      RequestError.BadRequest
+    )
+  }
+
+  if (time_slots.length > MAX_EVENT_TIME_SLOTS) {
+    throw new RequestError(
+      `Maximum allowed time slots ${MAX_EVENT_TIME_SLOTS}`,
+      RequestError.BadRequest
+    )
+  }
+
+  if (time_slots.length > 1 && recurrent_frequency === Frequency.HOURLY) {
+    throw new RequestError(
+      `Multiple time slots are not supported for HOURLY recurrence`,
+      RequestError.BadRequest
+    )
+  }
+
+  const times = new Set<number>()
+  for (const slot of time_slots) {
+    if (times.has(slot.time)) {
+      throw new RequestError(
+        `Duplicated time slot at "${slot.time}"`,
+        RequestError.BadRequest
+      )
+    }
+    times.add(slot.time)
+
+    if (slot.duration < 0 || slot.duration > max_duration) {
+      throw new RequestError(
+        `Maximum allowed duration ${max_duration / Time.Hour}Hrs`,
+        RequestError.BadRequest
+      )
+    }
+  }
+}
+
 export function calculateRecurrentProperties(
   event: Partial<RecurrentEventAttributes> &
     Partial<Pick<EventAttributes, "recurrent_dates">> &
     Pick<EventAttributes, "start_at" | "duration" | "finish_at">
-): RecurrentEventAttributes &
+): Omit<RecurrentEventAttributes, "time_slots"> &
   Pick<
     EventAttributes,
-    "start_at" | "duration" | "finish_at" | "recurrent_dates"
+    "start_at" | "duration" | "finish_at" | "recurrent_dates" | "time_slots"
   > {
   const now = Date.now()
-  const start_at = Time.date(event.start_at)
-  const finish_at = new Date(start_at.getTime() + event.duration)
+  const raw_start_at = Time.date(event.start_at)
   const duration = Math.max(event.duration, 0)
+  const time_slots = normalizeTimeSlots(
+    event.time_slots,
+    raw_start_at,
+    duration
+  )
+  // time_slots is the source of truth for times-of-day: start_at is
+  // normalized to the earliest slot and duration mirrors that slot.
+  // When no slots were provided, normalizeTimeSlots derived the slot
+  // FROM start_at/duration, so both expressions below are identities
+  // and legacy behavior is preserved unchanged.
+  const start_at = applyTimeOfDay(
+    raw_start_at,
+    time_slots[0].time,
+    raw_start_at.getUTCSeconds(),
+    raw_start_at.getUTCMilliseconds()
+  )
+  const finish_at = finishForDate(start_at, time_slots)
   const previous_recurrent_dates =
     (event.recurrent &&
       (event.recurrent_dates || []).filter(
-        (date) => date.getTime() + duration <= now
+        (date) => finishForDate(date, time_slots).getTime() <= now
       )) ||
     []
-  const recurrent: RecurrentEventAttributes &
+  const recurrent: Omit<RecurrentEventAttributes, "time_slots"> &
     Pick<
       EventAttributes,
-      "start_at" | "duration" | "finish_at" | "recurrent_dates"
+      "start_at" | "duration" | "finish_at" | "recurrent_dates" | "time_slots"
     > = {
     start_at,
-    duration,
+    duration: time_slots[0].duration,
     finish_at,
+    time_slots,
     recurrent: false,
     recurrent_interval: 1,
     recurrent_frequency: null,
@@ -424,19 +612,25 @@ export function calculateRecurrentProperties(
     const recurrent_dates = futureRecurrentDates(recurrent)
 
     if (recurrent_dates.length) {
-      const last_date = new Date(recurrent_dates[recurrent_dates.length - 1])
-      last_date.setUTCHours(start_at.getUTCHours())
-      last_date.setUTCMinutes(start_at.getUTCMinutes())
-      last_date.setUTCSeconds(start_at.getUTCSeconds())
-      last_date.setUTCMilliseconds(start_at.getUTCMilliseconds())
       recurrent.recurrent_dates = recurrent_dates
-      recurrent.finish_at = new Date(last_date.getTime() + event.duration)
     }
   }
 
   if (recurrent.recurrent_dates.length === 0) {
-    recurrent.recurrent_dates.push(start_at)
+    recurrent.recurrent_dates.push(
+      ...datesForDay(
+        start_at,
+        time_slots,
+        start_at.getUTCSeconds(),
+        start_at.getUTCMilliseconds()
+      )
+    )
   }
+
+  recurrent.finish_at = finishForDate(
+    recurrent.recurrent_dates[recurrent.recurrent_dates.length - 1],
+    time_slots
+  )
 
   return recurrent
 }
@@ -450,16 +644,16 @@ export function calculateNextRecurrentDates(
 
   if (
     !temp_start_time_at ||
-    (temp_start_time_at && temp_start_time_at.getTime() + event.duration <= now)
+    finishForDate(temp_start_time_at, event.time_slots).getTime() <= now
   ) {
     temp_start_time_at =
       event.recurrent_dates.find(
-        (date) => date.getTime() + event.duration > now
+        (date) => finishForDate(date, event.time_slots).getTime() > now
       ) || event.recurrent_dates[event.recurrent_dates.length - 1]
   }
   return {
     next_start_at: temp_start_time_at,
-    next_finish_at: Time(temp_start_time_at).add(event.duration).toDate(),
+    next_finish_at: finishForDate(temp_start_time_at, event.time_slots),
   }
 }
 

--- a/src/migrations/1783547966933_add-time-slots-to-events-table.ts
+++ b/src/migrations/1783547966933_add-time-slots-to-events-table.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate"
+
+import Model from "../entities/Event/model"
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn(Model.tableName, {
+    time_slots: { type: "JSONB", notNull: true, default: "[]" },
+  })
+
+  pgm.sql(`
+    UPDATE "${Model.tableName}"
+    SET "time_slots" = jsonb_build_array(
+      jsonb_build_object(
+        'time',
+        (
+          EXTRACT(HOUR FROM "start_at" AT TIME ZONE 'UTC') * 60 +
+          EXTRACT(MINUTE FROM "start_at" AT TIME ZONE 'UTC')
+        )::int,
+        'duration',
+        "duration"
+      )
+    )
+    WHERE "time_slots" = '[]'::jsonb;
+  `)
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(Model.tableName, "time_slots")
+}

--- a/test/integration/getEvents.test.ts
+++ b/test/integration/getEvents.test.ts
@@ -2,6 +2,7 @@ import { AuthIdentity } from "@dcl/crypto/dist/types"
 import { signedHeaderFactory } from "decentraland-crypto-fetch"
 import supertest from "supertest"
 
+import EventModel from "../../src/entities/Event/model"
 import { DeprecatedEventAttributes } from "../../src/entities/Event/types"
 import { seedEvent } from "../mocks/event"
 import { createIdentity } from "../mocks/identity"
@@ -385,6 +386,93 @@ describe("GET /api/events/:event_id", () => {
       expect(response.body.data.rejected).toBe(true)
       expect(response.body.data.contact).toBe("owner@example.com")
       expect(response.body.data.details).toBe("Private details")
+    })
+  })
+})
+
+describe("EventModel.getEventsStartingInRange", () => {
+  beforeAll(async () => {
+    await initTestDb()
+    dbInitialized = true
+  })
+
+  afterAll(async () => {
+    if (dbInitialized) {
+      await closeTestDb()
+    }
+  })
+
+  afterEach(async () => {
+    if (dbInitialized) {
+      await cleanTables()
+    }
+  })
+
+  describe("when a multi-slot event's later slot enters the window while next_start_at still points at the earlier slot", () => {
+    let event: DeprecatedEventAttributes
+    let slotB: Date
+
+    beforeEach(async () => {
+      const now = Date.now()
+      const slotA = new Date(now - 30 * 60 * 1000) // live now
+      slotB = new Date(now + 55 * 60 * 1000) // starts in 55 min
+
+      event = await seedEvent({
+        start_at: slotA,
+        finish_at: new Date(slotB.getTime() + 3600000),
+        duration: 3600000,
+        time_slots: [
+          {
+            time: slotA.getUTCHours() * 60 + slotA.getUTCMinutes(),
+            duration: 3600000,
+          },
+          {
+            time: slotB.getUTCHours() * 60 + slotB.getUTCMinutes(),
+            duration: 3600000,
+          },
+        ],
+        recurrent_dates: [slotA, slotB],
+        // pinned to the live slot, as the cron would leave it
+        next_start_at: slotA,
+        next_finish_at: new Date(slotA.getTime() + 3600000),
+      })
+    })
+
+    it("should match the event through its materialized occurrences", async () => {
+      const results = await EventModel.getEventsStartingInRange(
+        slotB.getTime() - 60 * 1000,
+        slotB.getTime() + 60 * 1000
+      )
+
+      expect(results.map((result) => result.id)).toContain(event.id)
+    })
+  })
+
+  describe("when a single-slot event has a future occurrence that next_start_at does not point at", () => {
+    let futureDate: Date
+
+    beforeEach(async () => {
+      const now = Date.now()
+      const current = new Date(now - 30 * 60 * 1000)
+      futureDate = new Date(now + 55 * 60 * 1000)
+
+      await seedEvent({
+        start_at: current,
+        finish_at: new Date(futureDate.getTime() + 3600000),
+        duration: 3600000,
+        recurrent_dates: [current, futureDate],
+        next_start_at: current,
+        next_finish_at: new Date(current.getTime() + 3600000),
+      })
+    })
+
+    it("should preserve the next_start_at-only matching for single-slot events", async () => {
+      const results = await EventModel.getEventsStartingInRange(
+        futureDate.getTime() - 60 * 1000,
+        futureDate.getTime() + 60 * 1000
+      )
+
+      expect(results).toEqual([])
     })
   })
 })

--- a/test/integration/updateEvent.test.ts
+++ b/test/integration/updateEvent.test.ts
@@ -355,6 +355,111 @@ describe("PATCH /api/events/:event_id", () => {
       })
     })
 
+    describe("and sets multiple time slots", () => {
+      let event: DeprecatedEventAttributes
+      let ownerIdentity: AuthIdentity
+
+      beforeEach(async () => {
+        const owner = await createIdentity()
+        ownerIdentity = owner.identity
+        event = await seedEvent({
+          user: owner.address,
+          recurrent: true,
+          recurrent_frequency: "WEEKLY" as any,
+          recurrent_interval: 1,
+          recurrent_until: new Date(Date.now() + 5 * 365 * 24 * 60 * 60 * 1000),
+        })
+      })
+
+      it("round-trips time_slots as a real array through the jsonb column", async () => {
+        const response = await signedPatch(
+          ownerIdentity,
+          `/api/events/${event.id}`,
+          {
+            time_slots: [
+              { time: 14 * 60, duration: 3600000 },
+              { time: 20 * 60, duration: 7200000 },
+            ],
+          }
+        )
+
+        expect(response.status).toBe(201)
+        expect(response.body.data.time_slots).toEqual([
+          { time: 14 * 60, duration: 3600000 },
+          { time: 20 * 60, duration: 7200000 },
+        ])
+        // recurrent_dates materializes both slots per recurrence day
+        expect(response.body.data.recurrent_dates.length).toBeGreaterThan(1)
+        expect(response.body.data.recurrent_dates.length % 2).toBe(0)
+
+        const fetched = await supertest(app)
+          .get(`/api/events/${event.id}`)
+          .expect(200)
+
+        expect(fetched.body.data.time_slots).toEqual([
+          { time: 14 * 60, duration: 3600000 },
+          { time: 20 * 60, duration: 7200000 },
+        ])
+      })
+
+      it("rejects a duration patch that conflicts with the stored multi-slot durations", async () => {
+        await signedPatch(ownerIdentity, `/api/events/${event.id}`, {
+          time_slots: [
+            { time: 14 * 60, duration: 3600000 },
+            { time: 20 * 60, duration: 7200000 },
+          ],
+        }).expect(201)
+
+        const response = await signedPatch(
+          ownerIdentity,
+          `/api/events/${event.id}`,
+          { duration: 5400000 }
+        )
+
+        expect(response.status).toBe(400)
+      })
+
+      it("accepts a round-trip patch that echoes the derived duration unchanged", async () => {
+        await signedPatch(ownerIdentity, `/api/events/${event.id}`, {
+          time_slots: [
+            { time: 14 * 60, duration: 3600000 },
+            { time: 20 * 60, duration: 7200000 },
+          ],
+        }).expect(201)
+
+        // Full-object clients resend duration as stored (the earliest
+        // slot's) — that must not 400.
+        const response = await signedPatch(
+          ownerIdentity,
+          `/api/events/${event.id}`,
+          { name: "Renamed", duration: 3600000 }
+        )
+
+        expect(response.status).toBe(201)
+        expect(response.body.data.name).toBe("Renamed")
+        expect(response.body.data.time_slots).toEqual([
+          { time: 14 * 60, duration: 3600000 },
+          { time: 20 * 60, duration: 7200000 },
+        ])
+      })
+
+      it("rejects multiple time slots combined with HOURLY recurrence", async () => {
+        const response = await signedPatch(
+          ownerIdentity,
+          `/api/events/${event.id}`,
+          {
+            recurrent_frequency: "HOURLY",
+            time_slots: [
+              { time: 0, duration: 1000 },
+              { time: 30, duration: 1000 },
+            ],
+          }
+        )
+
+        expect(response.status).toBe(400)
+      })
+    })
+
     describe("and updates owner-only fields", () => {
       let event: DeprecatedEventAttributes
       let ownerIdentity: AuthIdentity
@@ -480,6 +585,73 @@ describe("PATCH /api/events/:event_id", () => {
           (e: DeprecatedEventAttributes) => e.id
         )
         expect(eventIds).not.toContain(event.id)
+      })
+    })
+
+    describe("and the event has a grandfathered duration above the maximum", () => {
+      let event: DeprecatedEventAttributes
+      let ownerIdentity: AuthIdentity
+      const grandfathered = 48 * 60 * 60 * 1000 // 48h, predates the 24h cap
+
+      beforeEach(async () => {
+        const owner = await createIdentity()
+        ownerIdentity = owner.identity
+        event = await seedEvent({
+          user: owner.address,
+          duration: grandfathered,
+          finish_at: new Date(
+            new Date("2030-01-01T00:00:00Z").getTime() + grandfathered
+          ),
+          time_slots: [{ time: 0, duration: grandfathered }],
+        })
+      })
+
+      it("still accepts an edit that does not touch the duration", async () => {
+        const response = await signedPatch(
+          ownerIdentity,
+          `/api/events/${event.id}`,
+          { name: "Renamed grandfathered event" }
+        )
+
+        expect(response.status).toBe(201)
+        expect(response.body.data.name).toBe("Renamed grandfathered event")
+        expect(response.body.data.duration).toBe(grandfathered)
+      })
+
+      it("still rejects growing the duration beyond the stored value", async () => {
+        const response = await signedPatch(
+          ownerIdentity,
+          `/api/events/${event.id}`,
+          { duration: grandfathered + 1 }
+        )
+
+        expect(response.status).toBe(400)
+      })
+    })
+
+    describe("and the event has a legacy zero duration", () => {
+      let event: DeprecatedEventAttributes
+      let ownerIdentity: AuthIdentity
+
+      beforeEach(async () => {
+        const owner = await createIdentity()
+        ownerIdentity = owner.identity
+        event = await seedEvent({
+          user: owner.address,
+          duration: 0,
+          finish_at: new Date("2030-01-01T00:00:00Z"),
+          time_slots: [{ time: 0, duration: 0 }],
+        })
+      })
+
+      it("still accepts an edit that does not touch the duration", async () => {
+        const response = await signedPatch(
+          ownerIdentity,
+          `/api/events/${event.id}`,
+          { name: "Renamed zero-duration event" }
+        )
+
+        expect(response.status).toBe(201)
       })
     })
 

--- a/test/mocks/event.ts
+++ b/test/mocks/event.ts
@@ -21,6 +21,7 @@ export async function seedEvent(
     next_start_at: startAt,
     next_finish_at: new Date("2030-01-01T01:00:00Z"),
     duration: 3600000,
+    time_slots: [{ time: 0, duration: 3600000 }],
     all_day: false,
     x: 0,
     y: 0,


### PR DESCRIPTION
Closes #962.

Lets a single event carry multiple time-of-day showings (e.g. a recurring "Watch Party Wednesday" at 14:00 UTC and 20:00 UTC) instead of forcing organizers to create one event per showing.

## Approach

New `time_slots jsonb` column on `events`: an array of `{ time, duration }` where `time` is minutes-since-midnight UTC and `duration` is milliseconds. It is the source of truth for the times-of-day; `start_at`/`duration` stay populated (normalized to the earliest slot) for backward compatibility. Recurrence expansion multiplies each RRULE day by the slots, so `recurrent_dates` holds one occurrence per slot per day. Per-slot durations are supported (the 14:00 show can last 1h and the 20:00 one 3h).

Events without `time_slots` behave exactly as before — the column is backfilled from `start_at`/`duration` for every existing row and derived on read when empty.

## Notable points

- `duration` on the response is the earliest slot's duration; consumers must use `next_finish_at` (or the matching `time_slots` entry) to compute occurrence end times rather than `next_start_at + duration`. Documented in `openapi.yaml`.
- Multiple slots are rejected for `HOURLY` recurrence (an hourly rule already emits one occurrence per hour).
- `time_slots` is written as real JSONB (node-postgres would otherwise serialize a JS array as a Postgres array literal).
- Notification look-ahead now matches any materialized occurrence for multi-slot events, so a later same-day showing still gets its "starts soon" reminder even while `next_start_at` points at the earlier slot.
- Grandfathered rows whose stored duration predates the 24h cap (or is zero) stay editable.

## Verification

- Unit + integration suites (new tests cover recurrence expansion, per-slot durations, validation, the JSONB round-trip against a real Postgres, and notification matching).
- Migration run against a copy of the production dataset: backfill correct, no rows left with an empty `time_slots`.

## Follow-up (out of scope)

- What's On page UX in `decentraland/sites` to create/display multi-slot events.
