### PR TITLE
fix: re-moderate approved events on content edits and sanitize description output

### DIFF
--- a/src/entities/Event/model.test.ts
+++ b/src/entities/Event/model.test.ts
@@ -1,5 +1,34 @@
 import EventModel from "./model"
-import { EventListOptions, EventListType } from "./types"
+import {
+  DeprecatedEventAttributes,
+  EventListOptions,
+  EventListType,
+  SessionEventAttributes,
+} from "./types"
+import { ProfileSettingsAttributes } from "../ProfileSettings/types"
+
+const TO_PUBLIC_USER = "0x1111111111111111111111111111111111111111"
+
+function createEvent(
+  overrides: Partial<DeprecatedEventAttributes> = {}
+): DeprecatedEventAttributes {
+  const startAt = new Date("2030-01-01T00:00:00Z")
+  return {
+    user: TO_PUBLIC_USER,
+    user_name: "Creator",
+    description: "Original description",
+    contact: null,
+    details: null,
+    estate_name: "Estate",
+    scene_name: null,
+    x: 10,
+    y: 20,
+    duration: 3600000,
+    next_start_at: startAt,
+    recurrent_dates: [startAt],
+    ...overrides,
+  } as unknown as DeprecatedEventAttributes
+}
 
 type SQLCondition = { text: string }
 
@@ -468,6 +497,47 @@ describe("EventModel.buildEventFilterConditions", () => {
 
         expect(hasCommunityIdCondition(conditions)).toBe(false)
       })
+    })
+  })
+})
+
+describe("EventModel.toPublic", () => {
+  let profile: ProfileSettingsAttributes
+
+  beforeEach(() => {
+    profile = { user: TO_PUBLIC_USER } as ProfileSettingsAttributes
+  })
+
+  describe("when the event description contains client-rendered markup", () => {
+    let result: SessionEventAttributes
+
+    beforeEach(() => {
+      const event = createEvent({
+        description:
+          'Join <link="decentraland://?position=0,0">click here</link>',
+      })
+      result = EventModel.toPublic(event, profile)
+    })
+
+    it("should strip the markup from the returned description", () => {
+      expect(result.description).toBe("Join click here")
+    })
+  })
+
+  describe("when the event description contains markdown", () => {
+    let result: SessionEventAttributes
+
+    beforeEach(() => {
+      const event = createEvent({
+        description: "See [our site](https://decentraland.org) for **details**",
+      })
+      result = EventModel.toPublic(event, profile)
+    })
+
+    it("should leave the markdown untouched", () => {
+      expect(result.description).toBe(
+        "See [our site](https://decentraland.org) for **details**"
+      )
     })
   })
 })

--- a/src/entities/Event/model.ts
+++ b/src/entities/Event/model.ts
@@ -24,6 +24,7 @@ import {
   SITEMAP_ITEMS_PER_PAGE,
   SessionEventAttributes,
 } from "./types"
+import { sanitizeEventDescription } from "./utils"
 import { getEventCreatorDisplayName } from "../../modules/decentralandFoundationAddresses"
 import EventAttendee from "../EventAttendee/model"
 import { ProfileSettingsAttributes } from "../ProfileSettings/types"
@@ -503,6 +504,7 @@ export default class EventModel extends Model<DeprecatedEventAttributes> {
 
     return {
       ...event,
+      description: sanitizeEventDescription(event.description),
       user_name: getEventCreatorDisplayName(event.user, event.user_name),
       estate_name: event.estate_name || event.scene_name,
       attending: !!event.attending,

--- a/src/entities/Event/routes/updateEvent.test.ts
+++ b/src/entities/Event/routes/updateEvent.test.ts
@@ -722,4 +722,323 @@ describe("updateEvent", () => {
       })
     })
   })
+
+  describe("when editing the content of an already-approved event", () => {
+    function mockUpdateSuccess() {
+      ;(EventModel.update as jest.Mock).mockResolvedValueOnce(undefined)
+      ;(EventModel.textsearch as jest.Mock).mockReturnValueOnce(null)
+      ;(EventModel.selectNextStartAt as jest.Mock).mockReturnValueOnce(
+        new Date("2030-01-01T00:00:00Z")
+      )
+      ;(EventModel.toPublic as jest.Mock).mockReturnValueOnce({})
+      ;(EventAttendeeModel.findOne as jest.Mock).mockResolvedValueOnce(null)
+      ;(
+        EventCategoryModel.validateCategories as jest.Mock
+      ).mockResolvedValueOnce(true)
+    }
+
+    describe("and the owner lacks approval permission", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({
+          approved: true,
+          approved_by: "0x9999999999999999999999999999999999999999",
+          highlighted: true,
+          trending: true,
+        })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, {
+          description: "Edited description",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should reset approval and clear promotion flags to re-queue for moderation", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            approved: false,
+            approved_by: null,
+            highlighted: false,
+            trending: false,
+          }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and the owner has the ApproveOwnEvent permission", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({ approved: true })
+        const profile = createProfileSettings(OWNER_ADDRESS, [
+          ProfilePermissions.ApproveOwnEvent,
+        ])
+        req = createRequest(OWNER_ADDRESS, {
+          description: "Edited description",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should keep the event approved", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: true }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and a moderator with edit and approve permissions edits it", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({ approved: true })
+        const profile = createProfileSettings(OTHER_USER_ADDRESS, [
+          ProfilePermissions.EditAnyEvent,
+          ProfilePermissions.ApproveAnyEvent,
+        ])
+        req = createRequest(OTHER_USER_ADDRESS, {
+          description: "Moderator reviewed description",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should keep the event approved because the edit is itself a review", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: true }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and an editor without approval permission edits it", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({
+          approved: true,
+          approved_by: "0x9999999999999999999999999999999999999999",
+        })
+        const profile = createProfileSettings(OTHER_USER_ADDRESS, [
+          ProfilePermissions.EditAnyEvent,
+        ])
+        req = createRequest(OTHER_USER_ADDRESS, {
+          description: "Editor changed description",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should reset approval to re-queue for moderation", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: false, approved_by: null }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and the owner edits only a non-content field", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({ approved: true })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, { details: "VIP details" })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should not reset approval", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.not.objectContaining({ approved: false }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and the owner changes the vertical image", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({ approved: true })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, {
+          image_vertical: "https://example.com/vertical.png",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should reset approval to re-queue for moderation", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: false }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and the owner changes the categories", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({ approved: true, categories: [] })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, { categories: ["art"] })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should reset approval to re-queue for moderation", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: false }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and the owner re-submits the same categories", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({ approved: true, categories: ["art"] })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, { categories: ["art"] })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should not reset approval", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.not.objectContaining({ approved: false }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and the owner switches the location to a world", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        const event = createBaseEvent({ approved: true, world: false })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, {
+          world: true,
+          server: "myworld.dcl.eth",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should reset approval to re-queue for moderation", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ approved: false }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and a non-content field is edited on a legacy approved world event with no image", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        // The world branch backfills a default image into updatedAttributes;
+        // detection must read the request, not the enriched attributes, so
+        // this non-content edit does not spuriously re-queue.
+        const event = createBaseEvent({
+          approved: true,
+          world: true,
+          server: "myworld.dcl.eth",
+          image: null,
+        })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, { contact: "new@example.com" })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should not reset approval", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.not.objectContaining({ approved: false }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+
+    describe("and a non-content edit carries the already-sanitized description", () => {
+      let req: WithAuthProfile<WithAuth>
+
+      beforeEach(() => {
+        // The stored description holds raw markup; the API exposes (and the
+        // client round-trips) the sanitized form. Comparing both sides
+        // through the sanitizer means resubmitting the sanitized text is not
+        // seen as a content change.
+        const event = createBaseEvent({
+          approved: true,
+          description: 'Hi <link="file://x">bad</link>',
+        })
+        const profile = createProfileSettings(OWNER_ADDRESS)
+        req = createRequest(OWNER_ADDRESS, {
+          contact: "new@example.com",
+          description: "Hi bad",
+        })
+        ;(getEvent as jest.Mock).mockResolvedValueOnce(event)
+        ;(getAuthProfileSettings as jest.Mock).mockResolvedValueOnce(profile)
+        ;(isAdmin as unknown as jest.Mock).mockReturnValue(false)
+        mockUpdateSuccess()
+      })
+
+      it("should not reset approval", async () => {
+        await updateEvent(req)
+
+        expect(EventModel.update).toHaveBeenCalledWith(
+          expect.not.objectContaining({ approved: false }),
+          { id: EVENT_ID }
+        )
+      })
+    })
+  })
 })

--- a/src/entities/Event/routes/updateEvent.ts
+++ b/src/entities/Event/routes/updateEvent.ts
@@ -54,6 +54,7 @@ import {
   calculateRecurrentProperties,
   estimateRecurrentPastIterations,
   eventTargetUrl,
+  sanitizeEventDescription,
   validateImageUrl,
   validateRejectionReason,
 } from "../utils"
@@ -66,6 +67,64 @@ const EVENTS_BASE_URL = env(
   "EVENTS_BASE_URL",
   "https://events.decentraland.org"
 )
+
+// Owner-editable fields that are scheduling/control only: changing them
+// doesn't alter what content is shown or where, so on their own they must
+// NOT push an already-approved event back through moderation.
+const NON_MODERATED_EDITABLE_FIELDS = new Set<string>([
+  "start_at",
+  "duration",
+  "all_day",
+  "recurrent",
+  "recurrent_frequency",
+  "recurrent_setpos",
+  "recurrent_monthday",
+  "recurrent_weekday_mask",
+  "recurrent_month_mask",
+  "recurrent_interval",
+  "recurrent_count",
+  "recurrent_until",
+  "rejected",
+])
+
+// Public, creator-editable content/location fields whose change re-opens
+// moderation — derived from the owner-editable surface minus the
+// scheduling/control fields above (name, description, image, image_vertical,
+// x, y, server, world, categories). Deriving it this way means any field
+// later added to `editEventAttributes` re-moderates by default (fail-safe),
+// and it closes the edit-after-approval bypass across the whole public
+// surface, not just the description.
+const MODERATED_CONTENT_FIELDS = editEventAttributes.filter(
+  (field) => !NON_MODERATED_EDITABLE_FIELDS.has(field)
+)
+
+// Whether a moderated field's incoming request value differs from what the
+// event currently holds. Compared against the raw request (not the enriched
+// `updatedAttributes`) so server-maintained defaults — e.g. the world branch
+// backfilling a missing image — never count as a user content change. The
+// description is compared through the same sanitizer the API exposes, so a
+// client round-tripping the already-sanitized text (identical on read and
+// write) isn't mistaken for an edit. Arrays (categories) compare by value.
+function isModeratedFieldChanged(
+  field: string,
+  next: unknown,
+  current: unknown
+): boolean {
+  if (field === "description") {
+    return (
+      sanitizeEventDescription(String(next ?? "")) !==
+      sanitizeEventDescription(String(current ?? ""))
+    )
+  }
+
+  if (Array.isArray(next) || Array.isArray(current)) {
+    const a = (Array.isArray(next) ? next : []).map(String).sort()
+    const b = (Array.isArray(current) ? current : []).map(String).sort()
+    return a.length !== b.length || a.some((value, index) => value !== b[index])
+  }
+
+  return next !== current
+}
 
 export type UpdateEventOptions = {
   event?: DeprecatedEventAttributes
@@ -336,6 +395,33 @@ export async function updateEventWithOptions(
   if (updatedAttributes.rejected) {
     updatedAttributes.rejected = true
     updatedAttributes.approved = false
+    updatedAttributes.highlighted = false
+    updatedAttributes.trending = false
+  }
+
+  // Re-queue an already-approved event for moderation whenever its
+  // content changes, unless the actor is authorized to approve — a
+  // moderator's edit is itself a review. Closes the edit-after-approval
+  // bypass where an owner could get a benign event approved and then edit
+  // in content that stayed live without re-review.
+  const actorCanApprove =
+    admin ||
+    isAdmin(user) ||
+    canApproveAnyEvent(profile) ||
+    (isOwner && canApproveOwnEvent(profile))
+  const requestBody = req.body as Record<string, unknown>
+  const moderatedContentChanged = MODERATED_CONTENT_FIELDS.some(
+    (field) =>
+      field in requestBody &&
+      isModeratedFieldChanged(
+        field,
+        requestBody[field],
+        event[field as keyof EventAttributes]
+      )
+  )
+  if (event.approved && moderatedContentChanged && !actorCanApprove) {
+    updatedAttributes.approved = false
+    updatedAttributes.approved_by = null
     updatedAttributes.highlighted = false
     updatedAttributes.trending = false
   }

--- a/src/entities/Event/utils.test.ts
+++ b/src/entities/Event/utils.test.ts
@@ -3,6 +3,7 @@ import {
   estimateRecurrentPastIterations,
   fromEventTime,
   futureRecurrentDates,
+  sanitizeEventDescription,
   toEventTime,
 } from "./utils"
 
@@ -307,6 +308,201 @@ describe("estimateRecurrentPastIterations", () => {
       })
       expect(result).toBeGreaterThan(360)
       expect(result).toBeLessThan(370)
+    })
+  })
+})
+
+describe("sanitizeEventDescription", () => {
+  describe("when the description embeds a TMP <link> tag to a custom protocol", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        'Join <link="decentraland://?position=0,0">click here</link>'
+      )
+    })
+
+    it("should strip both sides of the unsafe link and keep the inner text", () => {
+      expect(result).toBe("Join click here")
+    })
+  })
+
+  describe("when the description embeds a <link> tag to a file/smb target", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        'a <link="file:///etc/passwd">x</link> b <link="smb://h/s">y</link> c'
+      )
+    })
+
+    it("should strip every unsafe link without leaving orphan tags", () => {
+      expect(result).toBe("a x b y c")
+    })
+  })
+
+  describe("when the description embeds a safe https <link> tag", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        'Join <link="https://decentraland.org">our site</link>'
+      )
+    })
+
+    it("should preserve the link tag untouched", () => {
+      expect(result).toBe(
+        'Join <link="https://decentraland.org">our site</link>'
+      )
+    })
+  })
+
+  describe("when the description embeds a safe http <link> tag", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription('<link="http://example.com">x</link>')
+    })
+
+    it("should preserve the link tag untouched", () => {
+      expect(result).toBe('<link="http://example.com">x</link>')
+    })
+  })
+
+  describe("when the description mixes a safe and an unsafe link", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        '<link="https://a.com">A</link><link="javascript:alert(1)">B</link>'
+      )
+    })
+
+    it("should keep the safe link and strip the unsafe one", () => {
+      expect(result).toBe('<link="https://a.com">A</link>B')
+    })
+  })
+
+  describe("when a link tag carries extra content after the target", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        "<link=https://a.com onclick=x>t</link>"
+      )
+    })
+
+    it("should strip the ambiguous tag (fail-safe)", () => {
+      expect(result).toBe("t")
+    })
+  })
+
+  describe("when a link points at the cloud-metadata IP", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        '<link="http://169.254.169.254/latest/meta-data/">x</link>'
+      )
+    })
+
+    it("should strip it", () => {
+      expect(result).toBe("x")
+    })
+  })
+
+  describe("when a link points at an obfuscated loopback IP", () => {
+    let result: string
+
+    beforeEach(() => {
+      // 2130706433 === 127.0.0.1; the URL parser normalizes it before the check.
+      result = sanitizeEventDescription('<link="http://2130706433/">x</link>')
+    })
+
+    it("should strip it", () => {
+      expect(result).toBe("x")
+    })
+  })
+
+  describe("when a link points at a private or localhost host", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        'a <link="http://192.168.1.1/">x</link> b <link="http://localhost:8080/">y</link> c'
+      )
+    })
+
+    it("should strip both internal links", () => {
+      expect(result).toBe("a x b y c")
+    })
+  })
+
+  describe("when a link points at a public host", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription('<link="https://8.8.8.8/">x</link>')
+    })
+
+    it("should keep it", () => {
+      expect(result).toBe('<link="https://8.8.8.8/">x</link>')
+    })
+  })
+
+  describe("when a link points at a single-label or reserved-suffix host", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        'a <link="http://router/">x</link> b <link="http://printer.lan/">y</link> c <link="http://nas.local/">z</link> d'
+      )
+    })
+
+    it("should strip these local-looking hosts", () => {
+      expect(result).toBe("a x b y c z d")
+    })
+  })
+
+  describe("when the description contains HTML anchor and image tags", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        '<a href="smb://attacker/share">x</a><img src="file:///etc/passwd">'
+      )
+    })
+
+    it("should remove every tag", () => {
+      expect(result).toBe("x")
+    })
+  })
+
+  describe("when the description contains markdown and comparison operators", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription(
+        "See [our site](https://decentraland.org) for **details** — 5 < 10 and 10 > 5 and I <3 events"
+      )
+    })
+
+    it("should preserve markdown, comparisons and non-tag angle brackets", () => {
+      expect(result).toBe(
+        "See [our site](https://decentraland.org) for **details** — 5 < 10 and 10 > 5 and I <3 events"
+      )
+    })
+  })
+
+  describe("when the description is empty", () => {
+    let result: string
+
+    beforeEach(() => {
+      result = sanitizeEventDescription("")
+    })
+
+    it("should return it unchanged", () => {
+      expect(result).toBe("")
     })
   })
 })

--- a/src/entities/Event/utils.ts
+++ b/src/entities/Event/utils.ts
@@ -633,6 +633,150 @@ export function validateDeletedReason(value: unknown): string | null {
   return reason
 }
 
+// Matches an HTML-/TMP-style markup tag: `<` followed by an optional
+// closing slash and a tag name that begins with a letter, up to the next
+// `>` (`<link="…">`, `</link>`, `<b>`, `<color=#fff>`, `<a href="…">`).
+// A bare `<` in prose ("5 < 10", "I <3 events") is left untouched because
+// it isn't immediately followed by a letter or slash, so plain text and
+// markdown ([text](url), **bold**, # headings) survive intact.
+const MARKUP_TAG_REGEX = /<\/?[a-zA-Z][^<>]*>/g
+
+// A TMP `<link=…>` / `<link="…">` opening tag, capturing the (optionally
+// quoted) target, and its matching `</link>` closing tag. The opening
+// pattern only matches a *clean* single-value link tag — any extra
+// attributes or stray quotes make it fall through to the strip branch, so
+// ambiguous tags are never preserved (fail-safe).
+const LINK_OPEN_TAG_REGEX = /^<link\s*=\s*"?([^"<>]*)"?\s*>$/i
+const LINK_CLOSE_TAG_REGEX = /^<\/link\s*>$/i
+
+// Hosts a link must never point at: loopback, private, link-local (incl.
+// the `169.254.169.254` cloud-metadata endpoint), carrier-grade NAT, and
+// internal/`localhost` names. `hostname` is already lowercased and
+// WHATWG-normalized by `new URL`, so obfuscated IPv4 forms (decimal, hex,
+// octal, short) arrive here as canonical dotted quads and can't slip past.
+// Reserved / internal-use DNS suffixes that never belong to a public host.
+const INTERNAL_HOST_SUFFIXES = [
+  ".localhost",
+  ".local",
+  ".internal",
+  ".intranet",
+  ".lan",
+  ".home",
+  ".corp",
+  ".home.arpa",
+]
+
+function isInternalLinkHost(hostname: string): boolean {
+  const host =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname
+
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (ipv4) {
+    const a = Number(ipv4[1])
+    const b = Number(ipv4[2])
+    return (
+      a === 0 || // "this host"
+      a === 127 || // loopback
+      a === 10 || // private
+      (a === 169 && b === 254) || // link-local incl. cloud metadata
+      (a === 172 && b >= 16 && b <= 31) || // private
+      (a === 192 && b === 168) || // private
+      (a === 100 && b >= 64 && b <= 127) // carrier-grade NAT
+    )
+  }
+
+  if (host.includes(":")) {
+    return (
+      host === "::1" || // loopback
+      host === "::" || // unspecified
+      /^fe[89ab]/.test(host) || // link-local fe80::/10
+      /^f[cd]/.test(host) || // unique-local fc00::/7
+      host.startsWith("::ffff:") // IPv4-mapped
+    )
+  }
+
+  // DNS name. A public host is a dotted FQDN under a real TLD, so a
+  // single-label name (`router`, `nas`, `localhost`) or a reserved
+  // internal-use suffix is treated as internal. DNS is not resolved here —
+  // this is a best-effort fail-closed for local-looking names, not proof the
+  // host is public.
+  if (!host.includes(".")) {
+    return true
+  }
+  return INTERNAL_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))
+}
+
+// Only http(s) links to a public host are safe to hand to the client, which
+// renders descriptions as TextMeshPro rich text and passes a clicked
+// `<link>` target straight to an unrestricted `Application.OpenURL`. A
+// non-web scheme (`file://`, `smb://`, `decentraland://`, `javascript:`,
+// `data:`, …) fires a local handler on the viewer's machine, and an http(s)
+// URL aimed at an internal/loopback/metadata host points the viewer's
+// browser at their own network — so both are stripped.
+function isSafeLinkTarget(target: string): boolean {
+  const trimmed = target.trim()
+  // A real URL never carries raw whitespace, so an inner space means the
+  // tag had extra junk after the target (e.g. `<link=https://a onclick=x>`);
+  // treat it as ambiguous and strip it.
+  if (/\s/.test(trimmed)) {
+    return false
+  }
+
+  let url: URL
+  try {
+    url = new URL(trimmed)
+  } catch {
+    return false
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return false
+  }
+
+  return !isInternalLinkHost(url.hostname.toLowerCase())
+}
+
+/**
+ * Neutralize unsafe markup in a user-authored description while preserving
+ * safe hyperlinks.
+ *
+ * The client renders descriptions as TextMeshPro rich text and turns
+ * `<link="target">text</link>` into a clickable link that reaches an
+ * unrestricted `Application.OpenURL(target)` — so a `file://` / `smb://` /
+ * `decentraland://` target fires a local handler on the viewer's machine.
+ * `<link>` tags pointing at http(s) URLs — the legitimate use case — are
+ * kept; links to any other scheme and every other markup tag are stripped.
+ * When a link is stripped, both its `<link>` and `</link>` sides are
+ * removed so no orphan tag is left behind. Markdown and non-tag
+ * comparisons like "5 < 10" survive intact.
+ */
+export function sanitizeEventDescription(description: string): string {
+  if (!description) {
+    return description
+  }
+
+  // `replace` visits matches left-to-right, so a stack records whether the
+  // `<link>` currently being closed was kept, to decide its `</link>`.
+  const openLinkKept: boolean[] = []
+  return description.replace(MARKUP_TAG_REGEX, (tag) => {
+    if (LINK_CLOSE_TAG_REGEX.test(tag)) {
+      // Drop orphan closers; otherwise mirror the matching opener.
+      return openLinkKept.length > 0 && openLinkKept.pop() ? tag : ""
+    }
+
+    const openMatch = tag.match(LINK_OPEN_TAG_REGEX)
+    if (openMatch) {
+      const keep = isSafeLinkTarget(openMatch[1])
+      openLinkKept.push(keep)
+      return keep ? tag : ""
+    }
+
+    return ""
+  })
+}
+
 export async function validateImageUrl(imageUrl: string) {
   const url = new URL(imageUrl)
   const whitelistedDomains = [BUCKET_URL].filter(

--- a/test/integration/updateEvent.test.ts
+++ b/test/integration/updateEvent.test.ts
@@ -102,6 +102,18 @@ function signedPatch(
   return supertest(app).patch(path).set(headerObj).send(body)
 }
 
+function signedGet(identity: AuthIdentity, path: string) {
+  const createHeaders = signedHeaderFactory()
+  const headers = createHeaders(identity, "GET", path, {})
+
+  const headerObj: Record<string, string> = {}
+  headers.forEach((value: string, key: string) => {
+    headerObj[key] = value
+  })
+
+  return supertest(app).get(path).set(headerObj)
+}
+
 function adminRequest(request: supertest.Test): supertest.Test {
   return request.set("Authorization", `Bearer ${ADMIN_TOKEN}`)
 }
@@ -347,9 +359,13 @@ describe("PATCH /api/events/:event_id", () => {
           name: "Persisted Name",
         }).expect(201)
 
-        const response = await supertest(app)
-          .get(`/api/events/${event.id}`)
-          .expect(200)
+        // Editing a content field (name) on an approved event re-queues it
+        // for moderation (approved -> false), so an anonymous read now 404s.
+        // Read back as the owner, who can always see their own pending event.
+        const response = await signedGet(
+          ownerIdentity,
+          `/api/events/${event.id}`
+        ).expect(200)
 
         expect(response.body.data.name).toBe("Persisted Name")
       })


### PR DESCRIPTION
## what

two related hardening changes for the event description path. the unity client renders event descriptions as textmeshpro rich text (no html, no markdown), so a crafted `<link="decentraland://...">` / `smb://` / `file://` tag in a description becomes a live, unprompted clickable link that reaches an unrestricted `Application.OpenURL` on the viewer's machine.

## changes

- **reset approval on content edits.** in `updateEventWithOptions`, when a content field (`name`, `description`, `image`, `x`, `y`, `server`) changes on an already-approved event, `approved` flips back to `false`, `approved_by` is cleared, and `highlighted`/`trending` are dropped so the event re-enters moderation. this is skipped when the actor is allowed to approve (admin token / `isAdmin` / `ApproveAnyEvent`, or the owner with `ApproveOwnEvent`), since their edit is itself a review. closes the edit-after-approval bypass where an owner could get a benign event approved and then swap in unreviewed content.
- **sanitize on output, keeping safe links.** new `sanitizeEventDescription` **keeps `<link>` tags pointing at http(s) URLs** (the legitimate use case — creators link out with custom anchor text) and strips links to any other scheme (`file://`, `smb://`, `decentraland://`, `javascript:`, `data:`, …) plus every other markup tag. both sides of a stripped link are removed so no orphan `</link>` remains; markdown and non-tag comparisons like `5 < 10` survive. matching is fail-safe: only a cleanly-parsed `<link=…>` whose target parses (via the WHATWG `URL`) as an `http(s)://` URL to a **public host** — no inner whitespace, and not a loopback / private / link-local (incl. the `169.254.169.254` cloud-metadata endpoint) / internal / `localhost` host — is kept; anything ambiguous is stripped. (obfuscated IPs like `http://2130706433/` are normalized by the parser before the host check, so they can't slip past.) applied in `model.ts` `toPublic`. stripping rather than html-escaping keeps the text clean, since tmp does not decode entities like `&lt;`.

## testing

- `sanitizeEventDescription` unit tests: safe http(s) link preservation, unsafe-scheme link + other-tag stripping, mixed safe/unsafe, ambiguous-tag fail-safe, markdown preservation, empty input.
- `toPublic` sanitization test.
- `updateEvent` re-moderation gate across the owner / editor / moderator permission matrix (resets vs keeps approved), plus a non-content-edit no-op case.
- full events unit suite green locally.

## related

part of a coordinated cross-repo change against client-rendered `<link>` markup:
- decentraland/events#986 — this pr (backend re-moderation + description strip)
- decentraland/places#852 — place description strip at ingestion
- decentraland/sites#688 — warn the owner when an approved-hangout edit needs re-review
